### PR TITLE
undo skip update helmrelease check

### DIFF
--- a/pkg/subscriber/github/subscriber_item.go
+++ b/pkg/subscriber/github/subscriber_item.go
@@ -455,17 +455,12 @@ func (ghsi *SubscriberItem) subscribeHelmCharts(indexFile *repo.IndexFile) (err 
 	for packageName, chartVersions := range indexFile.Entries {
 		klog.V(4).Infof("chart: %s\n%v", packageName, chartVersions)
 
-		dpl, skip, err := utils.CreateHelmCRDeployable(
+		dpl, err := utils.CreateHelmCRDeployable(
 			"", packageName, chartVersions, ghsi.synchronizer.LocalClient, ghsi.Channel, ghsi.Subscription)
 
 		if err != nil {
 			klog.Error("Failed to create a helmrelease CR deployable, err: ", err)
 			return err
-		}
-
-		if skip {
-			pkgMap[dpl.GetName()] = true
-			continue
 		}
 
 		err = ghsi.synchronizer.RegisterTemplate(hostkey, dpl, syncsource)

--- a/pkg/subscriber/helmrepo/subscriber_item.go
+++ b/pkg/subscriber/helmrepo/subscriber_item.go
@@ -271,17 +271,12 @@ func (hrsi *SubscriberItem) manageHelmCR(indexFile *repo.IndexFile, repoURL stri
 	for packageName, chartVersions := range indexFile.Entries {
 		klog.V(5).Infof("chart: %s\n%v", packageName, chartVersions)
 
-		dpl, skip, err := utils.CreateHelmCRDeployable(
+		dpl, err := utils.CreateHelmCRDeployable(
 			repoURL, packageName, chartVersions, hrsi.synchronizer.LocalClient, hrsi.Channel, hrsi.Subscription)
 
 		if err != nil {
 			klog.Error("Failed to create a helmrelease CR deployable, err: ", err)
 			return err
-		}
-
-		if skip {
-			pkgMap[dpl.GetName()] = true
-			continue
 		}
 
 		err = hrsi.synchronizer.RegisterTemplate(hostkey, dpl, syncsource)

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -93,12 +93,10 @@ func CreateOrUpdateHelmChart(
 	chartVersions repo.ChartVersions,
 	client client.Client,
 	channel *chnv1.Channel,
-	sub *appv1.Subscription) (helmRelease *releasev1.HelmRelease, create bool, err error) {
+	sub *appv1.Subscription) (helmRelease *releasev1.HelmRelease, err error) {
 	helmRelease = &releasev1.HelmRelease{}
 	err = client.Get(context.TODO(),
 		types.NamespacedName{Name: releaseCRName, Namespace: sub.Namespace}, helmRelease)
-
-	create = false
 
 	source := &releasev1.Source{
 		SourceType: releasev1.HelmRepoSourceType,
@@ -121,8 +119,6 @@ func CreateOrUpdateHelmChart(
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.V(2).Infof("Create helmRelease %s", releaseCRName)
-
-			create = true
 
 			helmRelease = &releasev1.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
@@ -149,7 +145,7 @@ func CreateOrUpdateHelmChart(
 			}
 		} else {
 			klog.Error("Error in getting existing helm release", err)
-			return nil, true, err
+			return nil, err
 		}
 	} else {
 		// set kind and apiversion, coz it is not in the resource get from k8s
@@ -165,7 +161,7 @@ func CreateOrUpdateHelmChart(
 		}
 	}
 
-	return helmRelease, create, nil
+	return helmRelease, nil
 }
 
 func Override(helmRelease *releasev1.HelmRelease, sub *appv1.Subscription) error {
@@ -209,42 +205,13 @@ func Override(helmRelease *releasev1.HelmRelease, sub *appv1.Subscription) error
 	return nil
 }
 
-func CompareHelmRelease(existingHr *releasev1.HelmRelease, newHr *releasev1.HelmRelease) bool {
-	existingHrRepo := existingHr.Repo
-	newHrRepo := newHr.Repo
-
-	existingHrSpec, err := json.Marshal(existingHr.Spec)
-	if err != nil {
-		klog.Error("Failed to marshal ", existingHr, " err:", err)
-		return false
-	}
-
-	existingHrSpecString := string(existingHrSpec)
-
-	newHrSpec, err := json.Marshal(newHr.Spec)
-	if err != nil {
-		klog.Error("Failed to marshal ", newHrSpec, " err:", err)
-		return false
-	}
-
-	newHrSpecString := string(newHrSpec)
-
-	return existingHrSpecString == newHrSpecString &&
-		existingHrRepo.Source.SourceType == newHrRepo.Source.SourceType &&
-		existingHrRepo.Source.HelmRepo.Urls[0] == newHrRepo.Source.HelmRepo.Urls[0] &&
-		existingHrRepo.ConfigMapRef == newHrRepo.ConfigMapRef &&
-		existingHrRepo.SecretRef == newHrRepo.SecretRef &&
-		existingHrRepo.ChartName == newHrRepo.ChartName &&
-		existingHrRepo.Version == newHrRepo.Version
-}
-
 func CreateHelmCRDeployable(
 	repoURL string,
 	packageName string,
 	chartVersions repo.ChartVersions,
 	client client.Client,
 	channel *chnv1.Channel,
-	sub *appv1.Subscription) (*dplv1.Deployable, bool, error) {
+	sub *appv1.Subscription) (*dplv1.Deployable, error) {
 	releaseCRName := GetPackageAlias(sub, packageName)
 	if releaseCRName == "" {
 		releaseCRName = packageName
@@ -257,7 +224,7 @@ func CreateHelmCRDeployable(
 
 	releaseCRName, err := GetReleaseName(releaseCRName)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	if channel == nil || !strings.EqualFold(string(channel.Spec.Type), chnv1.ChannelTypeGitHub) {
@@ -266,7 +233,7 @@ func CreateHelmCRDeployable(
 
 			if err != nil {
 				klog.Error("Failed to parse url with error:", err)
-				return nil, false, err
+				return nil, err
 			}
 
 			if parsedURL.Scheme == "local" {
@@ -277,19 +244,19 @@ func CreateHelmCRDeployable(
 		}
 	}
 
-	helmRelease, isCreate, err := CreateOrUpdateHelmChart(
+	helmRelease, err := CreateOrUpdateHelmChart(
 		packageName, releaseCRName, chartVersions, client, channel, sub)
 
 	if err != nil {
 		klog.Error("Failed to create or update helm chart ", packageName, " err:", err)
-		return nil, false, err
+		return nil, err
 	}
 
 	err = Override(helmRelease, sub)
 
 	if err != nil {
 		klog.Error("Failed to override ", helmRelease.Name, " err:", err)
-		return nil, false, err
+		return nil, err
 	}
 
 	if helmRelease.Spec == nil {
@@ -298,7 +265,7 @@ func CreateHelmCRDeployable(
 		err := yaml.Unmarshal([]byte("{\"\":\"\"}"), &spec)
 		if err != nil {
 			klog.Error("Failed to create an empty spec for helm release", helmRelease)
-			return nil, false, err
+			return nil, err
 		}
 
 		helmRelease.Spec = spec
@@ -313,31 +280,19 @@ func CreateHelmCRDeployable(
 		dpl.Namespace = channel.Namespace
 	}
 
-	if !isCreate {
-		existingHelmRelease := &releasev1.HelmRelease{}
-
-		err = client.Get(context.TODO(),
-			types.NamespacedName{Name: releaseCRName, Namespace: sub.Namespace}, existingHelmRelease)
-		if err == nil && CompareHelmRelease(existingHelmRelease, helmRelease) {
-			klog.V(2).Infof("Skipping deployable for %s", helmRelease.Name)
-
-			return dpl, true, nil
-		}
-	}
-
 	dpl.Spec.Template = &runtime.RawExtension{}
 	dpl.Spec.Template.Raw, err = json.Marshal(helmRelease)
 
 	if err != nil {
 		klog.Error("Failed to mashall helm release", helmRelease)
-		return nil, false, err
+		return nil, err
 	}
 
 	dplanno := make(map[string]string)
 	dplanno[dplv1.AnnotationLocal] = "true"
 	dpl.SetAnnotations(dplanno)
 
-	return dpl, false, nil
+	return dpl, nil
 }
 
 func getOverrides(packageName string, sub *appv1.Subscription) dplv1.Overrides {

--- a/pkg/utils/helmrepo_test.go
+++ b/pkg/utils/helmrepo_test.go
@@ -90,9 +90,8 @@ func TestCreateOrUpdateHelmChart(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	githubsub.UID = "dummyuid"
-	helmrelease, create, err := CreateOrUpdateHelmChart("chart1", "chart1-1.0.0", indexFile.Entries["chart1"], c, githubchn, githubsub)
+	helmrelease, err := CreateOrUpdateHelmChart("chart1", "chart1-1.0.0", indexFile.Entries["chart1"], c, githubchn, githubsub)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(create).To(gomega.BeTrue())
 	g.Expect(helmrelease).NotTo(gomega.BeNil())
 
 	err = c.Create(context.TODO(), helmrelease)
@@ -101,9 +100,8 @@ func TestCreateOrUpdateHelmChart(t *testing.T) {
 	// Sleep to make sure the helm release is created in the test kube
 	time.Sleep(5 * time.Second)
 
-	helmrelease, create, err = CreateOrUpdateHelmChart("chart1", "chart1-1.0.0", indexFile.Entries["chart1"], c, githubchn, githubsub)
+	helmrelease, err = CreateOrUpdateHelmChart("chart1", "chart1-1.0.0", indexFile.Entries["chart1"], c, githubchn, githubsub)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(create).To(gomega.BeFalse())
 	g.Expect(helmrelease).NotTo(gomega.BeNil())
 }
 
@@ -266,9 +264,8 @@ persistence:
 	time.Sleep(3 * time.Second)
 
 	sub2.UID = "dummyuid"
-	helmrelease, create, err := CreateOrUpdateHelmChart("chart1", "chart1-1.1.1", indexFile.Entries["chart1"], c, githubchn, sub2)
+	helmrelease, err := CreateOrUpdateHelmChart("chart1", "chart1-1.1.1", indexFile.Entries["chart1"], c, githubchn, sub2)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(create).To(gomega.BeTrue())
 	g.Expect(helmrelease).NotTo(gomega.BeNil())
 
 	err = Override(helmrelease, sub2)
@@ -310,14 +307,12 @@ func TestCreateHelmCRDeployable(t *testing.T) {
 
 	githubsub.UID = "dummyuid"
 
-	dpl, create, err := CreateHelmCRDeployable("../..", "chart1", indexFile.Entries["chart1"], c, githubchn, githubsub)
+	dpl, err := CreateHelmCRDeployable("../..", "chart1", indexFile.Entries["chart1"], c, githubchn, githubsub)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(create).To(gomega.BeFalse())
 	g.Expect(dpl).NotTo(gomega.BeNil())
 
 	githubchn.Spec.Type = chnv1.ChannelTypeHelmRepo
-	dpl, create, err = CreateHelmCRDeployable("../..", "chart1", indexFile.Entries["chart1"], c, githubchn, githubsub)
+	dpl, err = CreateHelmCRDeployable("../..", "chart1", indexFile.Entries["chart1"], c, githubchn, githubsub)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(create).To(gomega.BeFalse())
 	g.Expect(dpl).NotTo(gomega.BeNil())
 }


### PR DESCRIPTION
The HelmRelease skip update check was only inspecting deployed release manifest which is not good enough to know if the actual resources are deployed successfully or not.

When the subscription controller starts, the helmrelease controller also starts and the helmrelease controller also generate update events making these skip checks pointless.

Signed-off-by: Mike Ng <ming@redhat.com>