### PR TITLE
Izhang issue 170

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -24,11 +24,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
-	dplv1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
-	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
-	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
-	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
 	"github.com/pkg/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,6 +34,12 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/kustomize/pkg/fs"
+
+	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
+	dplv1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
+	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
+	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
+	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
 )
 
 type kubeResource struct {

--- a/pkg/synchronizer/kubernetes/discovery.go
+++ b/pkg/synchronizer/kubernetes/discovery.go
@@ -124,7 +124,7 @@ func (sync *KubeSynchronizer) GetValidatedGVK(org schema.GroupVersionKind) *sche
 		return nil
 	}
 
-	res := &schema.GroupVersionKind{}
+	res := schema.GroupVersionKind{}
 	found := false
 	// return the right version of gv
 	for gvk := range sync.KubeResources {
@@ -133,13 +133,13 @@ func (sync *KubeSynchronizer) GetValidatedGVK(org schema.GroupVersionKind) *sche
 				return &gvk
 			}
 
-			res = &gvk
+			res = gvk
 			found = true
 		}
 	}
 
 	if found {
-		return res
+		return &res
 	}
 
 	return nil

--- a/pkg/synchronizer/kubernetes/sync_test.go
+++ b/pkg/synchronizer/kubernetes/sync_test.go
@@ -128,6 +128,18 @@ func TestGVKValidation(t *testing.T) {
 	}
 	validgvk := schema.GroupVersionKind{
 		Group:   "apps",
+		Version: "v1beta1",
+		Kind:    "StatefulSet",
+	}
+	g.Expect(sync.GetValidatedGVK(gvk)).To(gomega.Equal(&validgvk))
+
+	gvk = schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "StatefulSet",
+	}
+	validgvk = schema.GroupVersionKind{
+		Group:   "apps",
 		Version: "v1",
 		Kind:    "StatefulSet",
 	}

--- a/pkg/synchronizer/kubernetes/sync_test.go
+++ b/pkg/synchronizer/kubernetes/sync_test.go
@@ -128,21 +128,13 @@ func TestGVKValidation(t *testing.T) {
 	}
 	validgvk := schema.GroupVersionKind{
 		Group:   "apps",
-		Version: "v1beta1",
+		Version: "v1",
 		Kind:    "StatefulSet",
 	}
-	g.Expect(sync.GetValidatedGVK(gvk)).To(gomega.Equal(&validgvk))
 
-	gvk = schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    "StatefulSet",
-	}
-	validgvk = schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    "StatefulSet",
-	}
+	t.Log(validgvk)
+	res := sync.GetValidatedGVK(gvk)
+	t.Log(res)
 	g.Expect(sync.GetValidatedGVK(gvk)).To(gomega.Equal(&validgvk))
 
 	gvk = schema.GroupVersionKind{

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -364,6 +364,9 @@ func (sync *KubeSynchronizer) createNewResourceByTemplateUnit(ri dynamic.Resourc
 
 	if obj != nil {
 		err = sync.Extension.UpdateHostStatus(err, tplunit.Unstructured, obj.Object["status"])
+		if obj.GroupVersionKind().Kind == crdKind {
+			sync.rediscoverResource()
+		}
 	} else {
 		err = sync.Extension.UpdateHostStatus(err, tplunit.Unstructured, nil)
 	}

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -364,6 +364,7 @@ func (sync *KubeSynchronizer) createNewResourceByTemplateUnit(ri dynamic.Resourc
 
 	if obj != nil {
 		err = sync.Extension.UpdateHostStatus(err, tplunit.Unstructured, obj.Object["status"])
+
 		if obj.GroupVersionKind().Kind == crdKind {
 			sync.rediscoverResource()
 		}

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -34,11 +34,12 @@ import (
 	gitignore "github.com/sabhiram/go-gitignore"
 
 	"github.com/ghodss/yaml"
+	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	dplv1alpha1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
 	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
-	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/pkg/utils/gitrepo_test.go
+++ b/pkg/utils/gitrepo_test.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
-	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
-	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
-	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
+	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
+	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
 var (

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -24,11 +24,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/ghodss/yaml"
-	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
-	dplv1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
-	dplutils "github.com/open-cluster-management/multicloud-operators-deployable/pkg/utils"
-	releasev1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
-	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,6 +33,12 @@ import (
 	"k8s.io/helm/pkg/repo"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
+	dplv1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
+	dplutils "github.com/open-cluster-management/multicloud-operators-deployable/pkg/utils"
+	releasev1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
+	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
 func GetPackageAlias(sub *appv1.Subscription, packageName string) string {

--- a/pkg/utils/helmrepo_test.go
+++ b/pkg/utils/helmrepo_test.go
@@ -21,10 +21,11 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 func TestGetPackageAlias(t *testing.T) {


### PR DESCRIPTION
Addressing:
https://github.com/open-cluster-management/multicloud-operators-subscription/issues/170
and 
https://github.com/open-cluster-management/multicloud-operators-subscription/issues/166

# 170, 
when a user uses a subscription to deploy a CRD at GVK `apiextensions.k8s.io/v1beta1`, our code will convert the `apiextensions.k8s.io/v1`, then the converted template will fail to apply.

User's yaml
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  labels:
    operator.kubevirt.io: ""
  name: kubevirts.kubevirt.io
spec:
```

The failure is due to that, for these 2 versions, the k8s have different validation rules. On `v1` there's an extra field required. So simply replace the GVK won't work for us.

At the meantime, if we use `kubectl` to apply the user's sample CRD at `apiextensions.k8s.io/v1beta1`, it will process without any issue. It seems our code is limiting incoming resources.

We are using the following code to limited the resources to be served, mainly limiting resource version.

**pkg/synchronizer/kubernetes/discovery.go**
`resources, err := discovery.NewDiscoveryClientForConfigOrDie(sync.localConfig).ServerPreferredResources()`

The `ServerPreferredResources` would only return the latest resource version to our code, then we convert out-of-date version to the lasted version.

I feel, we should use `ServerResources` to list all the resource versions(GVK) since we should reflect the full capacity of the managed cluster... but maybe there are some other design considerations against doing a full GVK list, can you please comment on this one @xiangjingli  @rokej  @kuanf 

# 166,
It seems when the CRD is updated, the GVK list(cache) is not updated right away, so our code will complain the kind is not supported yet.

I believe we can force the GVK list to rebuild via,

```
pkg/synchronizer/kubernetes/synchronizer.go
sync.rediscoverResource()
```
 The other changes are mainly for the format issues.
