### PR TITLE
Update gitrepo.go

### DIFF
--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -482,7 +482,7 @@ func matchUserSubAdmin(client client.Client, userIdentity, userGroups string) bo
 	err := client.Get(context.TODO(), types.NamespacedName{Name: appv1.SubscriptionAdmin}, foundClusterRoleBinding)
 
 	if err == nil {
-		klog.Info("ClusterRoleBinding subscription-admin found.")
+		klog.Info("ClusterRoleBinding acm-subscription-admin found.")
 
 		for _, subject := range foundClusterRoleBinding.Subjects {
 			if strings.Trim(subject.Name, "") == strings.Trim(userIdentity, "") && strings.Trim(subject.Kind, "") == "User" {
@@ -503,6 +503,8 @@ func matchUserSubAdmin(client client.Client, userIdentity, userGroups string) bo
 	} else {
 		klog.Error(err)
 	}
+
+	foundClusterRoleBinding = nil
 
 	return isUserSubAdmin
 }

--- a/pkg/utils/gitrepo_test.go
+++ b/pkg/utils/gitrepo_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
@@ -528,6 +529,8 @@ webhooks:
 
 	defer c.Delete(context.TODO(), theWebhook)
 
+	time.Sleep(1 * time.Second)
+
 	subscriptionYAML = `apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
@@ -575,6 +578,8 @@ func TestIsClusterAdminRemote(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	defer c.Delete(context.TODO(), clusterRoleBinding)
+
+	time.Sleep(1 * time.Second)
 
 	webhookYAML := `apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/pkg/utils/gitrepo_test.go
+++ b/pkg/utils/gitrepo_test.go
@@ -526,6 +526,8 @@ webhooks:
 	err = c.Create(context.TODO(), theWebhook)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
+	defer c.Delete(context.TODO(), theWebhook)
+
 	subscriptionYAML = `apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
@@ -544,9 +546,6 @@ metadata:
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	g.Expect(IsClusterAdmin(c, subscription)).To(gomega.BeFalse())
-
-	err = c.Delete(context.TODO(), theWebhook)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 func TestIsClusterAdminRemote(t *testing.T) {
@@ -570,8 +569,12 @@ func TestIsClusterAdminRemote(t *testing.T) {
 	err = c.Create(context.TODO(), clusterRole)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
+	defer c.Delete(context.TODO(), clusterRole)
+
 	err = c.Create(context.TODO(), clusterRoleBinding)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), clusterRoleBinding)
 
 	webhookYAML := `apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -595,6 +598,8 @@ webhooks:
 
 	err = c.Create(context.TODO(), theWebhook)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), theWebhook)
 
 	// user group: subscription-admin,test-group
 	// user identity: bob
@@ -664,15 +669,6 @@ metadata:
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	g.Expect(IsClusterAdmin(c, subscription)).To(gomega.BeFalse())
-
-	err = c.Delete(context.TODO(), clusterRole)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = c.Delete(context.TODO(), clusterRoleBinding)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = c.Delete(context.TODO(), theWebhook)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 func subAdminClusterRole() *rbacv1.ClusterRole {


### PR DESCRIPTION
`acm-subscription-admin` ClusterRoleBinding data needs to be refreshed every time subscription user is processed.