### PR TITLE
Izhang fix reference namespace

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -132,6 +132,7 @@ type ReconcileSubscription struct {
 // Reconcile reads that state of the cluster for a Subscription object and makes changes based on the state read
 // and what is in the Subscription.Spec
 func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
 	klog.Info("Standalone/Endpoint Reconciling subscription: ", request.NamespacedName)
 
 	instance := &appv1.Subscription{}
@@ -290,16 +291,23 @@ func (r *ReconcileSubscription) doReconcile(instance *appv1.Subscription) error 
 
 	if instance.Spec.PackageFilter != nil && instance.Spec.PackageFilter.FilterRef != nil {
 		subitem.SubscriptionConfigMap = &corev1.ConfigMap{}
-		subcfgkey := types.NamespacedName{
+		subcfgkeyL := types.NamespacedName{
 			Name:      instance.Spec.PackageFilter.FilterRef.Name,
-			Namespace: instance.Namespace,
+			Namespace: instance.GetNamespace(),
 		}
 
-		errLocal := r.Client.Get(context.TODO(), subcfgkey, subitem.SubscriptionConfigMap)
-		errRemote := r.hubclient.Get(context.TODO(), subcfgkey, subitem.SubscriptionConfigMap)
+		subcfgkeyR := types.NamespacedName{
+			Name: instance.Spec.PackageFilter.FilterRef.Name,
+			// the reference should sitting in side the channels namespace
+			Namespace: chnkey.Namespace,
+		}
+
+		errLocal := r.Client.Get(context.TODO(), subcfgkeyL, subitem.SubscriptionConfigMap)
+		errRemote := r.hubclient.Get(context.TODO(), subcfgkeyL, subitem.SubscriptionConfigMap)
 
 		if errRemote != nil && errLocal != nil {
-			return gerr.Wrapf(err, "failed to get reference configMap %v of subsciption %v from hub", subcfgkey.String(), instance.GetName())
+			return gerr.Wrapf(errRemote, "failed to get reference configMap at local %v or hub %v of subsciption %v from hub",
+				subcfgkeyL.String(), subcfgkeyL.String(), instance.GetName())
 		}
 	}
 

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -303,11 +303,11 @@ func (r *ReconcileSubscription) doReconcile(instance *appv1.Subscription) error 
 		}
 
 		errLocal := r.Client.Get(context.TODO(), subcfgkeyL, subitem.SubscriptionConfigMap)
-		errRemote := r.hubclient.Get(context.TODO(), subcfgkeyL, subitem.SubscriptionConfigMap)
+		errRemote := r.hubclient.Get(context.TODO(), subcfgkeyR, subitem.SubscriptionConfigMap)
 
 		if errRemote != nil && errLocal != nil {
 			return gerr.Wrapf(errRemote, "failed to get reference configMap at local %v or hub %v of subsciption %v from hub",
-				subcfgkeyL.String(), subcfgkeyL.String(), instance.GetName())
+				subcfgkeyL.String(), subcfgkeyR.String(), instance.GetName())
 		}
 	}
 

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -132,8 +132,8 @@ type ReconcileSubscription struct {
 // Reconcile reads that state of the cluster for a Subscription object and makes changes based on the state read
 // and what is in the Subscription.Spec
 func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-
 	klog.Info("Standalone/Endpoint Reconciling subscription: ", request.NamespacedName)
+	defer klog.Info("Exit Reconciling subscription: ", request.NamespacedName)
 
 	instance := &appv1.Subscription{}
 	err := r.Get(context.TODO(), request.NamespacedName, instance)


### PR DESCRIPTION
Fix the following error on spoke subscription:

```
  reason: 'failed to get reference configMap git-sub-ns/guestbook of subsciption git-sub
    from hub: configmaps "guestbook" is forbidden: User "hcm:clusters:izhang-manage:izhang-manage"
    cannot get resource "configmaps" in API group "" in the namespace "git-sub-ns"'
```
On spoke, the subscription supposes to check against the channel's namespace for referred `configmap` instead of the subscription's namespace.