### PR TITLE
Continuously reconcile differences in cluster resources with repo

### DIFF
--- a/pkg/subscriber/git/git_subscriber.go
+++ b/pkg/subscriber/git/git_subscriber.go
@@ -108,9 +108,6 @@ func (ghs *Subscriber) SubscribeItem(subitem *appv1alpha1.SubscriberItem) error 
 
 	ghs.itemmap[itemkey] = ghssubitem
 
-	// Set it back to false so subscription retries until it is set to true
-	ghssubitem.successful = false
-
 	// If the channel has annotation webhookenabled="true", do not poll the repo.
 	// Do subscription only on webhook events.
 	if strings.EqualFold(ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationWebhookEnabled], "true") {

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -136,6 +136,8 @@ func (ghsi *SubscriberItem) doSubscription() error {
 		return err
 	}
 
+	klog.Info("Git commit: ", commitID)
+
 	ghsi.resources = []kubesynchronizer.DplUnit{}
 
 	err = ghsi.sortClonedGitRepo()

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -76,7 +76,7 @@ func (sync *KubeSynchronizer) checkServerObjects(gvk schema.GroupVersionKind, re
 		if !ok {
 			// Harvest from system
 			if obj.GetDeletionTimestamp() == nil {
-				klog.V(3).Infof("Havesting tplunit from cluster host: %#v, obj: %#v, TemplateMap: %#v", dpl, obj, res.TemplateMap)
+				klog.Infof("Havesting tplunit from cluster host: %#v, obj: %#v, TemplateMap: %#v", dpl, obj, res.TemplateMap)
 
 				unit := &TemplateUnit{
 					ResourceUpdated: false,
@@ -549,13 +549,13 @@ func (sync *KubeSynchronizer) RegisterTemplate(host types.NamespacedName, instan
 		}
 	}
 
-	klog.V(4).Info("overrided template: ", template)
+	klog.V(4).Info("overrode template: ", template)
 	// skip no-op to template
 
-	if existingTemplateUnit != nil && reflect.DeepEqual(existingTemplateUnit.Unstructured, template) {
-		klog.V(2).Info("Skipping.. template in registry is the same ", existingTemplateUnit)
-		return nil
-	}
+	//if existingTemplateUnit != nil && reflect.DeepEqual(existingTemplateUnit.Unstructured, template) {
+	//	klog.V(2).Info("Skipping.. template in registry is the same ", existingTemplateUnit)
+	//	return nil
+	//}
 
 	templateUnit := &TemplateUnit{
 		ResourceUpdated: false,

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -76,7 +76,7 @@ func (sync *KubeSynchronizer) checkServerObjects(gvk schema.GroupVersionKind, re
 		if !ok {
 			// Harvest from system
 			if obj.GetDeletionTimestamp() == nil {
-				klog.Infof("Havesting tplunit from cluster host: %#v, obj: %#v, TemplateMap: %#v", dpl, obj, res.TemplateMap)
+				klog.V(3).Infof("Havesting tplunit from cluster host: %#v, obj: %#v, TemplateMap: %#v", dpl, obj, res.TemplateMap)
 
 				unit := &TemplateUnit{
 					ResourceUpdated: false,
@@ -551,11 +551,6 @@ func (sync *KubeSynchronizer) RegisterTemplate(host types.NamespacedName, instan
 
 	klog.V(4).Info("overrode template: ", template)
 	// skip no-op to template
-
-	//if existingTemplateUnit != nil && reflect.DeepEqual(existingTemplateUnit.Unstructured, template) {
-	//	klog.V(2).Info("Skipping.. template in registry is the same ", existingTemplateUnit)
-	//	return nil
-	//}
 
 	templateUnit := &TemplateUnit{
 		ResourceUpdated: false,


### PR DESCRIPTION
Git repo subscription used to reconcile a resource only when the commit ID of the subscribed repo is changed and the resource has changed in the repo. Once the resource is applied to cluster, any manual changes to the resource are not reconciled until those conditions are met. This PR is to change the behaviour of the subscription so that it continuously reconciles cluster resources to the repository's resources. The repository is the single source of truth.