### PR TITLE
Improve subscription status

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -58,14 +58,14 @@ type kubeResourceMetadata struct {
 }
 
 // UpdateGitDeployablesAnnotation clones the git repo and regenerate deployables and update annotation if needed
-func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscription) bool {
+func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscription) (bool, error) {
 	updated := false
 
 	channel, err := r.getChannel(sub)
 
 	if err != nil {
 		klog.Errorf("Failed to find a channel for subscription: %s", sub.GetName())
-		return false
+		return false, err
 	}
 
 	if utils.IsGitChannel(string(channel.Spec.Type)) {
@@ -75,6 +75,7 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 
 		if err != nil {
 			klog.Errorf("Failed to get secret for channel: %s", channel.GetName())
+			return false, err
 		}
 
 		commit, err := utils.CloneGitRepo(channel.Spec.Pathname,
@@ -85,7 +86,7 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 
 		if err != nil {
 			klog.Error(err.Error())
-			return false
+			return false, err
 		}
 
 		annotations := sub.GetAnnotations()
@@ -107,7 +108,7 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 
 		if err != nil {
 			klog.Error(err.Error())
-			return false
+			return false, err
 		}
 
 		r.updateGitSubDeployablesAnnotation(sub)
@@ -125,7 +126,7 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 		}
 	}
 
-	return updated
+	return updated, nil
 }
 
 // AddClusterAdminAnnotation adds cluster-admin annotation if conditions are met

--- a/pkg/controller/mcmhub/gitrepo_sync_test.go
+++ b/pkg/controller/mcmhub/gitrepo_sync_test.go
@@ -83,7 +83,8 @@ func TestUpdateGitDeployablesAnnotation(t *testing.T) {
 	githubsub.SetAnnotations(annotations)
 
 	// No channel yet. It will fail and return false.
-	ret := rec.UpdateGitDeployablesAnnotation(githubsub)
+	ret, err := rec.UpdateGitDeployablesAnnotation(githubsub)
+	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(ret).To(gomega.BeFalse())
 
 	err = c.Create(context.TODO(), githubchn)
@@ -91,7 +92,8 @@ func TestUpdateGitDeployablesAnnotation(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	ret = rec.UpdateGitDeployablesAnnotation(githubsub)
+	ret, err = rec.UpdateGitDeployablesAnnotation(githubsub)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(ret).To(gomega.BeTrue())
 
 	time.Sleep(2 * time.Second)

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -62,11 +62,16 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1alpha1.Subscription)
 
 	switch tp := strings.ToLower(string(channel.Spec.Type)); tp {
 	case chnv1alpha1.ChannelTypeGit, chnv1alpha1.ChannelTypeGitHub:
-		updateSubDplAnno = r.UpdateGitDeployablesAnnotation(sub)
+		updateSubDplAnno, err = r.UpdateGitDeployablesAnnotation(sub)
 	case chnv1alpha1.ChannelTypeHelmRepo:
 		updateSubDplAnno = UpdateHelmTopoAnnotation(r.Client, r.cfg, sub)
 	default:
 		updateSubDplAnno = r.UpdateDeployablesAnnotation(sub)
+	}
+
+	if err != nil {
+		klog.Errorf("Failed to update deployable annotation for git: %s", sub.GetName())
+		return err
 	}
 
 	klog.Infof("update Subscription: %v, update Subscription Deployable Annotation: %v", updateSub, updateSubDplAnno)

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -320,7 +320,10 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 
 	// process as hub subscription, generate deployable to propagate
 	pl := instance.Spec.Placement
-	if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) {
+	if pl == nil {
+		instance.Status.Phase = appv1.SubscriptionPropagationFailed
+		instance.Status.Reason = "Placement must be specified"
+	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) {
 		err = r.doMCMHubReconcile(instance)
 
 		if err != nil {


### PR DESCRIPTION
When there is no placement in subscription, 

```
status:
  lastUpdateTime: "2020-07-06T18:57:22Z"
  message: Active
  phase: PropagationFailed
  reason: Placement must be specified
```

If it fails to process git subscription in hub, save why it failed in the subscription status message like this.

```
status:
  lastUpdateTime: "2020-07-06T18:58:54Z"
  message: Active
  phase: PropagationFailed
  reason: 'lstat /tmp/demo-subscription/master/wrongresources: no such file or directory'
```