### PR TITLE
Continuous helmrepo reconcile

### DIFF
--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -53,7 +53,6 @@ type SubscriberItem struct {
 	hash         string
 	stopch       chan struct{}
 	syncinterval int
-	success      bool
 	synchronizer SyncSource
 }
 
@@ -123,16 +122,10 @@ func (hrsi *SubscriberItem) doSubscription() {
 
 	klog.V(4).Infof("Check if helmRepo %s changed with hash %s", repoURL, hash)
 
-	if hash != hrsi.hash || !hrsi.success {
-		if err := hrsi.processSubscription(); err != nil {
-			klog.Error("Failed to process helm repo subscription with error:", err)
+	if err := hrsi.processSubscription(); err != nil {
+		klog.Error("Failed to process helm repo subscription with error:", err)
 
-			hrsi.success = false
-
-			return
-		}
-
-		hrsi.success = true
+		return
 	}
 }
 


### PR DESCRIPTION
It looks like this problem has been around for a long time. The subscription controller reconciles only if there is some change in the source helm repository (index.yaml). So if you delete a `helmrelease` but there is no change in the helm repository, the deleted helmrelease will not be recreated.