### PR TITLE
Fix namespace subscription reconcile status update

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -177,7 +177,14 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 	if pl != nil && pl.Local != nil && *pl.Local {
 		reconcileErr := r.doReconcile(instance)
 
+		// doReconcile updates the subscription. Later this function fails to update the subscription status
+		// if the same subscription resource is used because it has already been updated by reconcile.
+		// Get the newly updated subscription resource.
+		_ = r.Get(context.TODO(), request.NamespacedName, instance)
+
 		instance.Status.Phase = appv1.SubscriptionSubscribed
+		instance.Status.Reason = ""
+
 		if reconcileErr != nil {
 			instance.Status.Phase = appv1.SubscriptionFailed
 			instance.Status.Reason = reconcileErr.Error()

--- a/pkg/utils/deployable.go
+++ b/pkg/utils/deployable.go
@@ -163,10 +163,12 @@ func UpdateDeployableStatus(statusClient client.Client, templateerr error, tplun
 		if status != nil {
 			a.ResourceStatus = &runtime.RawExtension{}
 			a.ResourceStatus.Raw, err = json.Marshal(status)
+
 			if err != nil {
 				klog.Info("Failed to mashall status for ", host, status, " with err:", err)
 			}
 		}
+
 		return a
 	}()
 
@@ -174,8 +176,8 @@ func UpdateDeployableStatus(statusClient client.Client, templateerr error, tplun
 
 	oldStatus := dpl.Status.DeepCopy()
 	if isStatusUpdated(*oldStatus, newStatus) {
-		statuStr := fmt.Sprintf("updating old %v, new %v", prettyStatus(dpl.Status), prettyStatus(newStatus))
-		klog.Info(fmt.Sprintf("host %v cmp status %v ", host.String(), statuStr))
+		statuStr := fmt.Sprintf("updating old %s, new %s", prettyStatus(dpl.Status), prettyStatus(newStatus))
+		klog.Info(fmt.Sprintf("host %s cmp status %s ", host.String(), statuStr))
 
 		now := metav1.Now()
 		dpl.Status = newStatus


### PR DESCRIPTION
For https://github.com/open-cluster-management/backlog/issues/3558.

When you update a namespace subscription in the hub cluster, the subscription reconcile in the managed cluster always fails because the reconcile updates the same resource twice: one for the actual subscription content and then later, its status. The status update fails and reschedule a retry in 1 second. But it fails again because of the same reason so the subscription in the managed cluster never gets updated.