### PR TITLE
implement the compare and submit approach of status field

### DIFF
--- a/pkg/subscriber/processdeployable/deployable_queue.go
+++ b/pkg/subscriber/processdeployable/deployable_queue.go
@@ -15,8 +15,6 @@
 package processdeployable
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
@@ -49,15 +47,8 @@ func Units(sub *subv1.Subscription, synchronizer SyncSource,
 		return err
 	}
 
-	if err := utils.ValidatePackagesInSubscriptionStatus(synchronizer.GetLocalClient(), sub, pkgMap); err != nil {
-		if err := synchronizer.GetLocalClient().Get(context.TODO(), hostkey, sub); err != nil {
-			klog.Error("Failed to get and subscription resource with error:", err)
-		}
-
-		if err := utils.ValidatePackagesInSubscriptionStatus(synchronizer.GetLocalClient(), sub, pkgMap); err != nil {
-			klog.Error("error in setting in cluster package status :", err)
-		}
-
+	//apply the update subscription status to cluster
+	if err := utils.SkipOrUpdateSubscriptionStatus(synchronizer.GetLocalClient(), sub); err != nil {
 		// if fail to update status, we want to retry as well
 		return err
 	}

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -402,6 +402,7 @@ func SkipOrUpdateSubscriptionStatus(clt client.Client, updateSub *appv1.Subscrip
 	if !isEqualSubscriptionStatus(oldStatus, upStatus) {
 		oldSub.Status = *upStatus
 		oldSub.Status.LastUpdateTime = metav1.Now()
+
 		if err := clt.Status().Update(context.TODO(), oldSub); err != nil {
 			return err
 		}

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -250,11 +250,11 @@ func isEmptySubscriptionStatus(a *appv1.SubscriptionStatus) bool {
 		return true
 	}
 
-	if len(a.Message) == 0 || len(a.Phase) == 0 || len(a.Reason) == 0 || len(a.Statuses) == 0 {
-		return true
+	if len(a.Message) != 0 || len(a.Phase) != 0 || len(a.Reason) != 0 || len(a.Statuses) != 0 {
+		return false
 	}
 
-	return false
+	return true
 }
 
 func isEqualSubscriptionStatus(a, b *appv1.SubscriptionStatus) bool {
@@ -394,7 +394,11 @@ func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tpl
 		}
 	}
 
+	klog.Infof("what's going on old status %v, new status %v", sub.Status, newStatus)
+
 	if isEmptySubscriptionStatus(newStatus) || !isEqualSubscriptionStatus(&sub.Status, newStatus) {
+		klog.Infof("innnnn what's going on old status %v, new status %v", sub.Status, newStatus)
+
 		sub.Status = *newStatus
 		sub.Status.LastUpdateTime = metav1.Now()
 
@@ -406,6 +410,15 @@ func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tpl
 	}
 
 	return nil
+}
+
+func printSubscriptionStatusStatus(s appv1.SubscriptionClusterStatusMap) {
+	for k, v := range s {
+		klog.Infof("resource key %v\n", k)
+		for kk, vv := range v.SubscriptionPackageStatus {
+			klog.Infof("resource key ---> %v %v\n", kk, vv)
+		}
+	}
 }
 
 func SkipOrUpdateSubscriptionStatus(clt client.Client, updateSub *appv1.Subscription) error {

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -385,6 +385,7 @@ func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tpl
 	if !isEqualSubscriptionStatus(&sub.Status, newStatus) {
 		sub.Status = *newStatus
 		sub.Status.LastUpdateTime = metav1.Now()
+
 		if err := statusClient.Status().Update(context.TODO(), sub); err != nil {
 			// want to print out the error log before leave
 			klog.Error("Failed to update status of deployable ", err)

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -394,10 +394,10 @@ func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tpl
 		}
 	}
 
-	klog.Infof("what's going on old status %v, new status %v", sub.Status, newStatus)
+	klog.V(1).Infof("what's going on old status %v, new status %v", sub.Status, newStatus)
 
 	if isEmptySubscriptionStatus(newStatus) || !isEqualSubscriptionStatus(&sub.Status, newStatus) {
-		klog.Infof("innnnn what's going on old status %v, new status %v", sub.Status, newStatus)
+		klog.V(1).Infof("innnnn %v, new status %v", sub.Status, newStatus)
 
 		sub.Status = *newStatus
 		sub.Status.LastUpdateTime = metav1.Now()
@@ -412,15 +412,6 @@ func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tpl
 	return nil
 }
 
-func printSubscriptionStatusStatus(s appv1.SubscriptionClusterStatusMap) {
-	for k, v := range s {
-		klog.Infof("resource key %v\n", k)
-		for kk, vv := range v.SubscriptionPackageStatus {
-			klog.Infof("resource key ---> %v %v\n", kk, vv)
-		}
-	}
-}
-
 func SkipOrUpdateSubscriptionStatus(clt client.Client, updateSub *appv1.Subscription) error {
 	oldSub := &appv1.Subscription{}
 
@@ -431,7 +422,7 @@ func SkipOrUpdateSubscriptionStatus(clt client.Client, updateSub *appv1.Subscrip
 	oldStatus := &oldSub.Status
 	upStatus := &updateSub.Status
 
-	if !isEqualSubscriptionStatus(oldStatus, upStatus) {
+	if isEmptySubscriptionStatus(upStatus) || !isEqualSubscriptionStatus(oldStatus, upStatus) {
 		oldSub.Status = *upStatus
 		oldSub.Status.LastUpdateTime = metav1.Now()
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -238,11 +238,23 @@ func SetInClusterPackageStatus(substatus *appv1.SubscriptionStatus, pkgname stri
 
 	newStatus.LastUpdateTime = metav1.Now()
 
-	if !isEqualSubscriptionStatus(substatus, newStatus) {
+	if isEmptySubscriptionStatus(newStatus) || !isEqualSubscriptionStatus(substatus, newStatus) {
 		newStatus.DeepCopyInto(substatus)
 	}
 
 	return nil
+}
+
+func isEmptySubscriptionStatus(a *appv1.SubscriptionStatus) bool {
+	if a == nil {
+		return true
+	}
+
+	if len(a.Message) == 0 || len(a.Phase) == 0 || len(a.Reason) == 0 || len(a.Statuses) == 0 {
+		return true
+	}
+
+	return false
 }
 
 func isEqualSubscriptionStatus(a, b *appv1.SubscriptionStatus) bool {
@@ -382,7 +394,7 @@ func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tpl
 		}
 	}
 
-	if !isEqualSubscriptionStatus(&sub.Status, newStatus) {
+	if isEmptySubscriptionStatus(newStatus) || !isEqualSubscriptionStatus(&sub.Status, newStatus) {
 		sub.Status = *newStatus
 		sub.Status.LastUpdateTime = metav1.Now()
 

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -191,6 +191,104 @@ func TestIsEqaulSubscriptionStatus(t *testing.T) {
 			},
 			expected: false,
 		},
+
+		{
+			name: "should be different due to cluster key",
+			givena: &appv1.SubscriptionStatus{
+				Reason:         "test",
+				LastUpdateTime: now,
+				Statuses: appv1.SubscriptionClusterStatusMap{
+					"/": &appv1.SubscriptionPerClusterStatus{
+						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
+							"package-a": {
+								Phase: appv1.SubscriptionSubscribed,
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+
+							"package-b": {
+								Phase: appv1.SubscriptionSubscribed,
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+						},
+					},
+				},
+			},
+			givenb: &appv1.SubscriptionStatus{
+				Reason:         "test",
+				LastUpdateTime: now,
+				Statuses: appv1.SubscriptionClusterStatusMap{
+					"/": &appv1.SubscriptionPerClusterStatus{
+						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
+							"package-a": {
+								Phase:          appv1.SubscriptionSubscribed,
+								LastUpdateTime: metav1.NewTime(now.Add(5 * time.Second)),
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+
+							"package-b": {
+								Phase:          appv1.SubscriptionSubscribed,
+								LastUpdateTime: metav1.NewTime(now.Add(5 * time.Second)),
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+
+		{
+			name: "should be different due to cluster key",
+			givena: &appv1.SubscriptionStatus{
+				Reason:         "test",
+				LastUpdateTime: now,
+				Statuses: appv1.SubscriptionClusterStatusMap{
+					"/": &appv1.SubscriptionPerClusterStatus{
+						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
+							"package-a": {
+								Phase: appv1.SubscriptionSubscribed,
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+
+							"package-b": {
+								Phase: appv1.SubscriptionSubscribed,
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+						},
+					},
+				},
+			},
+			givenb: &appv1.SubscriptionStatus{
+				Reason:         "test",
+				LastUpdateTime: now,
+				Statuses: appv1.SubscriptionClusterStatusMap{
+					"/": &appv1.SubscriptionPerClusterStatus{
+						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
+							"package-a": {
+								Phase:          appv1.SubscriptionSubscribed,
+								LastUpdateTime: metav1.NewTime(now.Add(5 * time.Second)),
+								ResourceStatus: &runtime.RawExtension{
+									Raw: rawResStatus,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -214,6 +312,7 @@ func TestIsEmptySubscriptionStatus(t *testing.T) {
 		{name: "should be true, nil pointer", expected: true, given: nil},
 		{name: "should be true, default status", expected: true, given: &appv1.SubscriptionStatus{}},
 		{name: "should be true, default status", expected: true, given: &appv1.SubscriptionStatus{Statuses: appv1.SubscriptionClusterStatusMap{}}},
+		{name: "should be true, default status", expected: false, given: &appv1.SubscriptionStatus{Message: "test"}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -92,7 +92,7 @@ func TestSetInClusterStatus(t *testing.T) {
 				Statuses: appv1.SubscriptionClusterStatusMap{
 					"/": &appv1.SubscriptionPerClusterStatus{
 						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-							"resource": &appv1.SubscriptionUnitStatus{
+							"resource": {
 								Phase: appv1.SubscriptionSubscribed,
 							},
 						},
@@ -116,7 +116,7 @@ func TestSetInClusterStatus(t *testing.T) {
 				Statuses: appv1.SubscriptionClusterStatusMap{
 					"/": &appv1.SubscriptionPerClusterStatus{
 						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-							"resource": &appv1.SubscriptionUnitStatus{
+							"resource": {
 								Phase: appv1.SubscriptionSubscribed,
 								ResourceStatus: &runtime.RawExtension{
 									Raw: rawResStatus,
@@ -132,7 +132,7 @@ func TestSetInClusterStatus(t *testing.T) {
 				Statuses: appv1.SubscriptionClusterStatusMap{
 					"/": &appv1.SubscriptionPerClusterStatus{
 						SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-							"resource": &appv1.SubscriptionUnitStatus{
+							"resource": {
 								Phase: appv1.SubscriptionSubscribed,
 							},
 						},
@@ -152,7 +152,6 @@ func TestSetInClusterStatus(t *testing.T) {
 			if !isEqualSubscriptionStatus(tt.givenSubStatus, tt.expectedStatus) {
 				t.Errorf("given (%v): expected %v", tt.givenSubStatus, tt.expectedStatus)
 			}
-
 		})
 	}
 }

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -215,6 +215,7 @@ func TestIsEmptySubscriptionStatus(t *testing.T) {
 		{name: "should be true, default status", expected: true, given: &appv1.SubscriptionStatus{}},
 		{name: "should be true, default status", expected: true, given: &appv1.SubscriptionStatus{Statuses: appv1.SubscriptionClusterStatusMap{}}},
 	}
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -222,8 +223,6 @@ func TestIsEmptySubscriptionStatus(t *testing.T) {
 			if actual != tt.expected {
 				t.Errorf("(%v): expected %v, actual %v", tt.given, tt.expected, actual)
 			}
-
 		})
 	}
-
 }


### PR DESCRIPTION
Reduce the invalidate status update, [issue](https://github.com/open-cluster-management/backlog/issues/3641)


This fix will do a comparison before update the subscription status, which will reduce the reconcile of subscriptions.

Signed-off-by: Ian Zhang <izhang@redhat.com>