### PR TITLE
deleted resources are re-created by the paused subscription

### DIFF
--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -305,13 +305,18 @@ func (sync *KubeSynchronizer) applyKindTemplates(res *ResourceMap) {
 
 func (sync *KubeSynchronizer) applyTemplate(nri dynamic.NamespaceableResourceInterface, namespaced bool,
 	k string, tplunit *TemplateUnit, isService bool) error {
-	klog.V(3).Info("Applying (key:", k, ") template:", tplunit, tplunit.Unstructured, "updated:", tplunit.ResourceUpdated)
+	klog.V(1).Info("Applying (key:", k, ") template:", tplunit, tplunit.Unstructured, "updated:", tplunit.ResourceUpdated)
 
 	var ri dynamic.ResourceInterface
 	if namespaced {
 		ri = nri.Namespace(tplunit.GetNamespace())
 	} else {
 		ri = nri
+	}
+
+	if !utils.AllowApplyTemplate(sync.LocalClient, tplunit.Unstructured) {
+		klog.Infof("Applying template is paused: %v/%v", tplunit.GetName(), tplunit.GetNamespace())
+		return nil
 	}
 
 	obj, err := ri.Get(context.TODO(), tplunit.GetName(), metav1.GetOptions{})

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -486,6 +486,38 @@ func GetPauseLabel(instance *appv1.Subscription) bool {
 	return false
 }
 
+// AllowApplyTemplate check if the template is allowed to apply based on its hosting subscription pause label
+// return false if the hosting subscription is paused.
+func AllowApplyTemplate(localClient client.Client, template *unstructured.Unstructured) bool {
+	// if the template is subscription kind, allow its update
+	if strings.EqualFold(template.GetKind(), "Subscription") {
+		return true
+	}
+
+	//if the template is not subscription kind, check if its hosting subscription is paused.
+	sub := &appv1.Subscription{}
+	subkey := GetHostSubscriptionFromObject(template)
+
+	if subkey == nil {
+		klog.V(1).Infof("The template does not have hosting subscription. template: %v/%v, annoation: %#v",
+			template.GetNamespace(), template.GetName(), template.GetAnnotations())
+		return true
+	}
+
+	err := localClient.Get(context.TODO(), *subkey, sub)
+
+	if err != nil {
+		klog.V(1).Infof("Failed to get subscription object. sub: %v, error: %v", *subkey, err)
+		return true
+	}
+
+	if GetPauseLabel(sub) {
+		return false
+	}
+
+	return true
+}
+
 //DeleteSubscriptionCRD deletes the Subscription CRD
 func DeleteSubscriptionCRD(runtimeClient client.Client, crdx *clientsetx.Clientset) {
 	sublist := &appv1.SubscriptionList{}


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

When the subscription synchronizer handles orphan resources,  need to stop applying them if its hosting subscription is paused.  The fix address the case:

1. paused subscription1, 
2. removed a resource that subscription1 created. It did not get recreated 
3. created subscription2. While the synchronizer processes subscription2, the deleted resources in the subscription1 are re-created.
