### PR TITLE
Use kustomize CLI to fix some issues

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,8 @@ RUN  microdnf update -y \
         && rpm -e --nodeps tzdata \
         && microdnf install tzdata \
         && microdnf install git \
-        &&  microdnf clean all
+        && microdnf install tar \
+        && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/multicluster-operators-subscription \
     USER_UID=1001 \
@@ -19,6 +20,12 @@ COPY build/_output/bin/uninstall-crd /usr/local/bin
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
+# install kustomize
+ENV KUSTOMIZE_VERSION 3.8.1
+RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -o /tmp/kustomize.tar.gz \
+     && tar zxvf /tmp/kustomize.tar.gz -C /usr/bin \
+     && chmod +x /usr/bin/kustomize
+     
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 	sigs.k8s.io/controller-runtime v0.6.0
-	sigs.k8s.io/kustomize v2.0.3+incompatible
 )
 
 replace (

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -447,7 +447,7 @@ func (r *ReconcileSubscription) subscribeKustomizations(chn *chnv1.Channel, sub 
 			}
 		}
 
-		cmd := exec.Command("kustomize", "build", kustomizeDir)
+		cmd := exec.Command("kustomize", "build", kustomizeDir) // #nosec G204 kustomizeDirs is not user input. Determined internally.
 
 		var out bytes.Buffer
 


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3774

k8s.io/cli-runtime/pkg/kustomize module does not support all the features that are supported by kustomize CLI. 

This PR also supports both string and YAML to override kustomization.yaml.