### PR TITLE
Subscription replace should annotate the objects like a normal subscription.

### DIFF
--- a/pkg/synchronizer/kubernetes/sync_test.go
+++ b/pkg/synchronizer/kubernetes/sync_test.go
@@ -784,11 +784,10 @@ var _ = Describe("test resource overwrite", func() {
 		// age field should be deleted because the reconcile option was replace
 		Expect(cm.Data["age"]).Should(Equal(""))
 
-		// The hosting annotations should not be added when existing resource, that is not owned by the subscription,
-		// gets overwritten
+		// If reconcile option is replace, the hosting annotations should added to existing resource, that is not owned by the subscription.
 		cmAnnotations = cm.GetAnnotations()
-		Expect(cmAnnotations["apps.open-cluster-management.io/hosting-deployable"]).To(Equal(""))
-		Expect(cmAnnotations["apps.open-cluster-management.io/hosting-subscription"]).To(Equal(""))
+		Expect(cmAnnotations["apps.open-cluster-management.io/hosting-deployable"]).To(Equal(configMapSharedkey.Namespace + "/" + configMapSharedkey.Name))
+		Expect(cmAnnotations["apps.open-cluster-management.io/hosting-subscription"]).To(Equal(configMapSharedkey.Namespace + "/" + configMapSharedkey.Name))
 	})
 
 	It("resource owned by others can be merged by subscription", func() {
@@ -865,7 +864,7 @@ var _ = Describe("test resource overwrite", func() {
 		// age field should be kept because the reconcile option was merge
 		Expect(cm.Data["age"]).Should(Equal("19"))
 
-		// The hosting annotations should not be added when existing resource, that is not owned by the subscription,
+		// With merge option, the hosting annotations should not be added when existing resource, that is not owned by the subscription,
 		// gets overwritten
 		cmAnnotations = cm.GetAnnotations()
 		Expect(cmAnnotations["apps.open-cluster-management.io/hosting-deployable"]).To(Equal(""))

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -267,7 +267,11 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 	newobj := tplunit.Unstructured.DeepCopy()
 	newobj.SetResourceVersion(obj.GetResourceVersion())
 
-	if overwrite {
+	// If subscription-admin chooses merge option, remove the typical annotations we add. This will avoid the resources being
+	// deleted when the subscription is removed.
+	// If subscription-admin chooses replace option, keep the typical annotations we add. Subscription takes over the resources.
+	// When the subscription is removed, the resources will be removed too.
+	if overwrite && merge {
 		// If overwriting someone else's resource, remove annotations like hosting subscription, hostring deployables... etc
 		newobj = utils.RemoveSubAnnotations(newobj)
 		newobj = utils.RemoveSubOwnerRef(newobj)


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/5623

If subscription-admin chooses `merge` option to update existing resources not owned by subscription, remove the typical annotations subscription controller adds. This will avoid the resources being deleted when the subscription is removed.

If subscription-admin chooses `replace` option to update existing resources not owned by subscription, keep the typical annotations subscription controller adds. Subscription takes over the resources. When the subscription is removed, the resources will be removed too.