### PR TITLE
remove unused func and test

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -97,7 +97,8 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 
 		// Compare the commit to the Git repo and update deployables only if the commit has changed
 		if !strings.EqualFold(annotations[appv1.AnnotationGitCommit], commit) {
-			// Delete the existing deployables and recreate them
+			// Delete the existing deployables that meets the subscription
+			// selector and recreate them
 			r.deleteSubscriptionDeployables(sub)
 
 			annotations[appv1.AnnotationGitCommit] = commit
@@ -389,6 +390,7 @@ func (r *ReconcileSubscription) processRepo(chn *chnv1.Channel, sub *appv1.Subsc
 func (r *ReconcileSubscription) deleteSubscriptionDeployables(sub *appv1.Subscription) {
 	klog.Info("Deleting sbscription deploaybles")
 
+	//get deployables that meet the subscription selector
 	subDeployables := r.getSubscriptionDeployables(sub)
 
 	// delete subscription deployables if exists.

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -211,7 +211,7 @@ func (a *AnsibleHooks) RegisterSubscription(subKey types.NamespacedName) error {
 
 	//check if the subIns have being changed compare to the hook registry, if
 	//changed then re-register the subscription
-	if !a.isSubscriptionUpdate(subIns, isSubscriptionSpecChange) {
+	if !a.isSubscriptionUpdate(subIns, a.isSubscriptionSpecChange) {
 		return nil
 	}
 
@@ -232,8 +232,9 @@ func (a *AnsibleHooks) RegisterSubscription(subKey types.NamespacedName) error {
 	return a.addHookToRegisitry(subIns)
 }
 
-func isSubscriptionSpecChange(o, n *subv1.Subscription) bool {
-	fmt.Println(o.GetGeneration(), n.GetGeneration())
+func (a *AnsibleHooks) isSubscriptionSpecChange(o, n *subv1.Subscription) bool {
+	a.logger.Info(fmt.Sprintf("isSubscriptionUpdate old: %d, new: %d", o.GetGeneration(), n.GetGeneration()))
+
 	return o.GetGeneration() != n.GetGeneration()
 }
 

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -175,6 +175,59 @@ var _ = Describe("multiple reconcile single of the same subscription instance sp
 	})
 })
 
+func UpdateHostDeployableStatus(clt client.Client, sKey types.NamespacedName, tPhase dplv1.DeployablePhase) error {
+	hubdpl := &dplv1.Deployable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sKey.Name + "-deployable",
+			Namespace: sKey.Namespace,
+		},
+		Spec: dplv1.DeployableSpec{
+			Template: &runtime.RawExtension{
+				Object: &corev1.ConfigMap{},
+			},
+		},
+	}
+
+	t := &dplv1.Deployable{}
+
+	hubdplKey := types.NamespacedName{Name: hubdpl.GetName(), Namespace: hubdpl.GetNamespace()}
+
+	if err := clt.Get(context.TODO(), hubdplKey, t); err != nil {
+		return nil
+	}
+
+	t.Status.Phase = tPhase
+	fmt.Printf("izhang -----> update host dpl \n%#v\n", t)
+
+	return clt.Status().Update(context.TODO(), t.DeepCopy())
+}
+
+func ManagedClusterUpdateHubStatus(clt client.Client, subKey types.NamespacedName, tPhase subv1.SubscriptionPhase) error {
+	a := &subv1.Subscription{}
+	ctx := context.TODO()
+
+	if err := clt.Get(ctx, subKey, a); err != nil {
+		return err
+	}
+
+	statusTS := metav1.Now()
+	a.Status.LastUpdateTime = statusTS
+	a.Status.Phase = subv1.SubscriptionPropagated
+	a.Status.Statuses = subv1.SubscriptionClusterStatusMap{
+		"spoke": &subv1.SubscriptionPerClusterStatus{
+			SubscriptionPackageStatus: map[string]*subv1.SubscriptionUnitStatus{
+				"pkg1": {
+					Phase:          tPhase,
+					LastUpdateTime: statusTS,
+				},
+			},
+		},
+	}
+
+	fmt.Printf("izhang -----> update managed status \n%#v\n", a)
+	return clt.Status().Update(ctx, a)
+}
+
 func forceUpdatePrehook(clt client.Client, preKey types.NamespacedName) error {
 	pre := &ansiblejob.AnsibleJob{}
 
@@ -187,32 +240,6 @@ func forceUpdatePrehook(clt client.Client, preKey types.NamespacedName) error {
 	newPre.Status.AnsibleJobResult.Status = "successful"
 
 	return clt.Status().Update(context.TODO(), newPre)
-}
-
-func forceUpdateSubDpl(clt client.Client, subIns *subv1.Subscription) error {
-	hubdpl := &dplv1.Deployable{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      subIns.Name + "-deployable",
-			Namespace: subIns.Namespace,
-		},
-		Spec: dplv1.DeployableSpec{
-			Template: &runtime.RawExtension{
-				Object: &corev1.ConfigMap{},
-			},
-		},
-	}
-
-	_ = clt.Create(context.TODO(), hubdpl)
-
-	t := &dplv1.Deployable{}
-
-	hubdplKey := types.NamespacedName{Name: hubdpl.GetName(), Namespace: hubdpl.GetNamespace()}
-
-	_ = clt.Get(context.TODO(), hubdplKey, t)
-
-	t.Status.Phase = dplv1.DeployablePropagated
-
-	return clt.Status().Update(context.TODO(), t.DeepCopy())
 }
 
 var _ = Describe("given a subscription pointing to a git path,where pre hook folder present", func() {
@@ -367,7 +394,7 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 		ctx      = context.TODO()
 	)
 
-	PIt("upon the change of a subscription, it should create 2nd ansiblejob instance for hook(s)", func() {
+	It("upon the change of a subscription, it should create 2nd ansiblejob instance for hook(s)", func() {
 		subIns := testPath.subIns.DeepCopy()
 		chnIns := testPath.chnIns.DeepCopy()
 
@@ -396,61 +423,18 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 
 		// mock the subscription deployable status to propagation,which is copied over to the
 		// subsritption status
-		mockManagedClusterUpdate := func() error {
-			a := &subv1.Subscription{}
-
-			if err := k8sClt.Get(ctx, subKey, a); err != nil {
-				return err
-			}
-
-			statusTS := metav1.Now()
-			a.Status.LastUpdateTime = statusTS
-			a.Status.Phase = subv1.SubscriptionPropagated
-			a.Status.Statuses = subv1.SubscriptionClusterStatusMap{
-				"spoke": &subv1.SubscriptionPerClusterStatus{
-					SubscriptionPackageStatus: map[string]*subv1.SubscriptionUnitStatus{
-						"pkg1": {
-							Phase:          subv1.SubscriptionSubscribed,
-							LastUpdateTime: statusTS,
-						},
-					},
-				},
-			}
-
-			return k8sClt.Status().Update(ctx, a)
+		mockManagedCluster := func() error {
+			return ManagedClusterUpdateHubStatus(k8sClt, subKey, subv1.SubscriptionSubscribed)
 		}
 
-		Eventually(mockManagedClusterUpdate, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(mockManagedCluster, pullInterval*5, pullInterval).Should(Succeed())
 
-		forceUpdateSubDplToProp := func() error {
-			hubdpl := &dplv1.Deployable{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      subIns.Name + "-deployable",
-					Namespace: subIns.Namespace,
-				},
-				Spec: dplv1.DeployableSpec{
-					Template: &runtime.RawExtension{
-						Object: &corev1.ConfigMap{},
-					},
-				},
-			}
-
-			t := &dplv1.Deployable{}
-
-			hubdplKey := types.NamespacedName{Name: hubdpl.GetName(), Namespace: hubdpl.GetNamespace()}
-
-			if err := k8sClt.Get(context.TODO(), hubdplKey, t); err != nil {
-				return nil
-			}
-
-			t.Status.Phase = dplv1.DeployablePropagated
-
-			return k8sClt.Status().Update(context.TODO(), t.DeepCopy())
+		mockHostDpl := func() error {
+			return UpdateHostDeployableStatus(k8sClt, subKey, dplv1.DeployablePropagated)
 		}
-
 		// mock the subscription deployable status to propagation,which is copied over to the
 		// subsritption status
-		Eventually(forceUpdateSubDplToProp, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(mockHostDpl, pullInterval*5, pullInterval).Should(Succeed())
 
 		ansibleIns := &ansiblejob.AnsibleJob{}
 		waitForPostHookCR := func() error {
@@ -470,7 +454,7 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 		}
 
 		// it seems the travis CI needs more time
-		Eventually(waitForPostHookCR, 8*pullInterval, pullInterval).Should(Succeed())
+		Eventually(waitForPostHookCR, 3*pullInterval, pullInterval).Should(Succeed())
 
 		//test if the ansiblejob have a owner set
 		Expect(ansibleIns.GetOwnerReferences()).ShouldNot(HaveLen(0))
@@ -486,7 +470,12 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 			return k8sClt.Update(context.TODO(), u.DeepCopy())
 		}
 
-		Eventually(modifySub, pullInterval*10, pullInterval).Should(Succeed())
+		Eventually(modifySub, pullInterval*5, pullInterval).Should(Succeed())
+
+		// since the modifySub will regenerate the deployable and managed
+		// cluster status, we meed to mock the process again
+		Eventually(mockManagedCluster, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(mockHostDpl, pullInterval*5, pullInterval).Should(Succeed())
 
 		waitFor2ndGenerateInstance := func() error {
 			aList := &ansiblejob.AnsibleJobList{}
@@ -514,10 +503,9 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 			return nil
 		}
 
-		Eventually(waitFor2ndGenerateInstance, pullInterval*8, pullInterval).Should(Succeed())
+		Eventually(waitFor2ndGenerateInstance, pullInterval*3, pullInterval).Should(Succeed())
 
 		// there's an update request triggered, so we might want to wait for a bit
-
 		waitFroPosthookStatus := func() error {
 			updateSub := &subv1.Subscription{}
 
@@ -563,60 +551,17 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 			Expect(k8sClt.Delete(ctx, subIns)).Should(Succeed())
 		}()
 
-		forceUpdateSubDplToProp := func() error {
-			hubdpl := &dplv1.Deployable{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      subIns.Name + "-deployable",
-					Namespace: subIns.Namespace,
-				},
-				Spec: dplv1.DeployableSpec{
-					Template: &runtime.RawExtension{
-						Object: &corev1.ConfigMap{},
-					},
-				},
-			}
-
-			t := &dplv1.Deployable{}
-
-			hubdplKey := types.NamespacedName{Name: hubdpl.GetName(), Namespace: hubdpl.GetNamespace()}
-
-			if err := k8sClt.Get(context.TODO(), hubdplKey, t); err != nil {
-				return nil
-			}
-
-			t.Status.Phase = dplv1.DeployablePropagated
-
-			return k8sClt.Status().Update(context.TODO(), t.DeepCopy())
-		}
-
 		// mock the subscription deployable status to propagation,which is copied over to the
 		// subsritption status
-		Eventually(forceUpdateSubDplToProp, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(
+			func() error {
+				return UpdateHostDeployableStatus(k8sClt, subKey, dplv1.DeployablePropagated)
+			}, pullInterval*5, pullInterval).Should(Succeed())
 
-		mockManagedClusterUpdate := func() error {
-			a := &subv1.Subscription{}
-
-			if err := k8sClt.Get(ctx, subKey, a); err != nil {
-				return err
-			}
-
-			statusTS := metav1.Now()
-			a.Status.LastUpdateTime = statusTS
-			a.Status.Statuses = subv1.SubscriptionClusterStatusMap{
-				"spoke": &subv1.SubscriptionPerClusterStatus{
-					SubscriptionPackageStatus: map[string]*subv1.SubscriptionUnitStatus{
-						"pkg1": {
-							Phase:          subv1.SubscriptionFailed,
-							LastUpdateTime: statusTS,
-						},
-					},
-				},
-			}
-
-			return k8sClt.Status().Update(ctx, a)
-		}
-
-		Eventually(mockManagedClusterUpdate, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(
+			func() error {
+				return ManagedClusterUpdateHubStatus(k8sClt, subKey, subv1.SubscriptionPropagationFailed)
+			}, pullInterval*5, pullInterval).Should(Succeed())
 
 		// failed to due the managed cluster isn't reporting back
 		waitForAnsibleJobs := func() error {
@@ -642,7 +587,7 @@ var _ = Describe("given a subscription pointing to a git path,where both pre and
 		ctx      = context.TODO()
 	)
 
-	PIt("should create 2 ansiblejob instance and they should be written into the subscription status", func() {
+	It("should create 2 ansiblejob instance and they should be written into the subscription status", func() {
 		subIns := testPath.subIns.DeepCopy()
 		subIns.SetNamespace(fmt.Sprintf("%s-pre-post-1", subIns.GetNamespace()))
 		subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
@@ -658,23 +603,24 @@ var _ = Describe("given a subscription pointing to a git path,where both pre and
 			Expect(k8sClt.Delete(ctx, subIns)).Should(Succeed())
 		}()
 
-		// mock the subscription deployable status,which is copied over to the
-		// subsritption status
-		//mock the status of managed cluster
-		Expect(forceUpdateSubDpl(k8sClt, subIns)).Should(Succeed())
+		mockManagedCluster := func() error {
+			return ManagedClusterUpdateHubStatus(k8sClt, subKey, subv1.SubscriptionSubscribed)
+		}
 
-		time.Sleep(3 * time.Second)
+		mockHostDpl := func() error {
+			return UpdateHostDeployableStatus(k8sClt, subKey, dplv1.DeployablePropagated)
+		}
 
 		preHookKey := types.NamespacedName{}
 
-		waitForAnsibleJobs := func() error {
+		waitForPreAnsibleJobs := func() error {
 			aList := &ansiblejob.AnsibleJobList{}
 			if err := k8sClt.List(context.TODO(), aList, &client.ListOptions{Namespace: subIns.GetNamespace()}); err != nil {
 				return err
 			}
 
 			if len(aList.Items) != 1 {
-				return errors.New("ansiblejob is not coming up")
+				return errors.New("pre ansiblejob is not coming up")
 			}
 
 			preHook := aList.Items[0].DeepCopy()
@@ -684,20 +630,32 @@ var _ = Describe("given a subscription pointing to a git path,where both pre and
 			return nil
 		}
 
-		Eventually(waitForAnsibleJobs, pullInterval*5, pullInterval).Should(Succeed())
-		//make sure the prehook is created
-		Expect(forceUpdatePrehook(k8sClt, preHookKey)).Should(Succeed())
+		Eventually(waitForPreAnsibleJobs, pullInterval*5, pullInterval).Should(Succeed())
+		//make sure the prehook is created and update with target status
+		Eventually(func() error {
+			return forceUpdatePrehook(k8sClt, preHookKey)
+		}, pullInterval*3, pullInterval).Should(Succeed())
+
+		// mock the subscription deployable status,which is copied over to the
+		// subsritption status
+		//mock the status of managed cluster
+		Eventually(mockManagedCluster, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(mockHostDpl, pullInterval*5, pullInterval).Should(Succeed())
 
 		postHookKey := types.NamespacedName{}
 
-		waitForAnsibleJobs = func() error {
+		waitForPostAnsibleJobs := func() error {
 			aList := &ansiblejob.AnsibleJobList{}
 			if err := k8sClt.List(context.TODO(), aList, &client.ListOptions{Namespace: subIns.GetNamespace()}); err != nil {
 				return err
 			}
 
-			if len(aList.Items) != 2 {
-				return errors.New("ansiblejob is not coming up")
+			for _, l := range aList.Items {
+				fmt.Printf("got ansiblejob %v/%v\n", l.GetNamespace(), l.GetName())
+			}
+
+			if len(aList.Items) < 2 {
+				return errors.New("post ansiblejob is not coming up")
 			}
 
 			for _, h := range aList.Items {
@@ -710,7 +668,7 @@ var _ = Describe("given a subscription pointing to a git path,where both pre and
 			return nil
 		}
 
-		Eventually(waitForAnsibleJobs, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(waitForPostAnsibleJobs, pullInterval*5, pullInterval).Should(Succeed())
 		// there's an update request triggered, so we might want to wait for a bit
 
 		waitFroPosthookStatus := func() error {

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -197,7 +197,6 @@ func UpdateHostDeployableStatus(clt client.Client, sKey types.NamespacedName, tP
 	}
 
 	t.Status.Phase = tPhase
-	fmt.Printf("izhang -----> update host dpl \n%#v\n", t)
 
 	return clt.Status().Update(context.TODO(), t.DeepCopy())
 }
@@ -224,7 +223,6 @@ func ManagedClusterUpdateHubStatus(clt client.Client, subKey types.NamespacedNam
 		},
 	}
 
-	fmt.Printf("izhang -----> update managed status \n%#v\n", a)
 	return clt.Status().Update(ctx, a)
 }
 

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -154,19 +154,6 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1alpha1.Subscription)
 	return err
 }
 
-// update subscription  rolling update target subscription changes or subscription deployable list changes
-func (r *ReconcileSubscription) setNewSubscription(sub *appv1alpha1.Subscription, updateSub, updateSubDplAnno bool) error {
-	if updateSub || updateSubDplAnno {
-		err := r.Update(context.TODO(), sub)
-		if err != nil {
-			klog.Infof("Updating Subscription failed. subscription: %#v, error: %#v", sub, err)
-			return err
-		}
-	}
-
-	return nil
-}
-
 //checkSubDeployables check differences between existing subscription dpl (found) and new subscription dpl (dpl)
 // This is caused by end-user updates on the orignal subscription.
 func checkSubDeployables(found, dpl *dplv1alpha1.Deployable) bool {

--- a/pkg/controller/mcmhub/hub_test.go
+++ b/pkg/controller/mcmhub/hub_test.go
@@ -150,42 +150,6 @@ status:
                     type: ReleaseFailed`
 )
 
-func TestSetNewSubscription(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	c = mgr.GetClient()
-
-	rec := newReconciler(mgr).(*ReconcileSubscription)
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
-	githubsub.UID = "dummyid"
-
-	annotations := make(map[string]string)
-	annotations[appv1.AnnotationGitPath] = "test/github"
-	githubsub.SetAnnotations(annotations)
-
-	err = rec.setNewSubscription(githubsub, true, false)
-	g.Expect(err).To(gomega.HaveOccurred())
-
-	err = c.Create(context.TODO(), githubsub)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = rec.setNewSubscription(githubsub, true, false)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = c.Delete(context.TODO(), githubsub)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-}
-
 func TestPrepareDeployableForSubscription(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -446,6 +446,7 @@ func DeleteInClusterPackageStatus(substatus *appv1.SubscriptionStatus, pkgname s
 // - nil:  success
 // - others: failed, with error message in reason
 func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tplunit metav1.Object, status interface{}, deletePkg bool) error {
+	fmt.Println("izhang is this called from managed --------------------")
 	klog.V(10).Info("Trying to update subscription status:", templateerr, tplunit.GetNamespace(), "/", tplunit.GetName(), status)
 
 	if tplunit == nil {

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -446,7 +446,6 @@ func DeleteInClusterPackageStatus(substatus *appv1.SubscriptionStatus, pkgname s
 // - nil:  success
 // - others: failed, with error message in reason
 func UpdateSubscriptionStatus(statusClient client.Client, templateerr error, tplunit metav1.Object, status interface{}, deletePkg bool) error {
-	fmt.Println("izhang is this called from managed --------------------")
 	klog.V(10).Info("Trying to update subscription status:", templateerr, tplunit.GetNamespace(), "/", tplunit.GetName(), status)
 
 	if tplunit == nil {


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Due to the reconcile changes, the `setNewSubscription` is not used anymore, since the compare and commit logic is moved to the main reconcile logic in the effort of reducing the reconcile signals.