### PR TITLE
get rid of the late update

### DIFF
--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -173,17 +173,17 @@ func (jIns *JobInstances) applyJobs(clt client.Client, subIns *subv1.Subscriptio
 		jKey := types.NamespacedName{Name: nx.GetName(), Namespace: nx.GetNamespace()}
 
 		if err := clt.Get(context.TODO(), jKey, job); err != nil {
-			if kerr.IsNotFound(err) {
-				if err := clt.Create(context.TODO(), &nx); err != nil {
-					if !kerr.IsAlreadyExists(err) {
-						return fmt.Errorf("failed to apply job %v, err: %v", k.String(), err)
-					}
-				}
-
-				logger.Info(fmt.Sprintf("applied ansiblejob %s/%s", nx.GetNamespace(), nx.GetName()))
+			if !kerr.IsNotFound(err) {
+				return fmt.Errorf("failed to get job %v, err: %v", jKey, err)
 			}
 
-			return fmt.Errorf("failed to get job %v, err: %v", jKey, err)
+			if err := clt.Create(context.TODO(), &nx); err != nil {
+				if !kerr.IsAlreadyExists(err) {
+					return fmt.Errorf("failed to apply job %v, err: %v", k.String(), err)
+				}
+			}
+
+			logger.Info(fmt.Sprintf("applied ansiblejob %s/%s", nx.GetNamespace(), nx.GetName()))
 		}
 	}
 

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -446,6 +446,8 @@ func (a *AnsibleHooks) HasHooks(hookType string, subKey types.NamespacedName) bo
 		if hks == nil || len(*hks) == 0 {
 			return false
 		}
+
+		return true
 	}
 
 	hks := a.registry[subKey].postHooks
@@ -478,7 +480,7 @@ func (a *AnsibleHooks) IsPostHooksCompleted(subKey types.NamespacedName) (bool, 
 
 func isJobRunSuccessful(job *ansiblejob.AnsibleJob, logger logr.Logger) bool {
 	curStatus := job.Status.AnsibleJobResult.Status
-	logger.V(1).Info(fmt.Sprintf("job: %#v, job status: %v", job, curStatus))
+	logger.V(1).Info(fmt.Sprintf("job %s status: %v", PrintHelper(job), curStatus))
 
 	return strings.EqualFold(curStatus, JobCompleted)
 }

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -666,7 +666,7 @@ var _ = Describe("given a subscription pointing to a git path,where both pre and
 			return nil
 		}
 
-		Eventually(waitForPostAnsibleJobs, pullInterval*5, pullInterval).Should(Succeed())
+		Eventually(waitForPostAnsibleJobs, pullInterval*10, pullInterval).Should(Succeed())
 		// there's an update request triggered, so we might want to wait for a bit
 
 		waitFroPosthookStatus := func() error {

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -293,7 +293,7 @@ var _ = Describe("given a subscription pointing to a git path,where pre hook fol
 		Expect(ansibleIns.GetOwnerReferences()).ShouldNot(HaveLen(0))
 
 		Expect(ansibleIns.Spec.TowerAuthSecretName).Should(Equal(GetReferenceString(&testPath.hookSecretRef)))
-		Expect(ansibleIns.Spec.JobTemplateName).Should(Equal("Demo Job Template"))
+		Expect(ansibleIns.Spec.JobTemplateName).ShouldNot(HaveLen(0))
 
 		an := ansibleIns.GetAnnotations()
 		Expect(an).ShouldNot(HaveLen(0))

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -749,6 +749,13 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 			return
 		}
 
+		//mostly the conflict is coming from the managed cluster update the hub
+		//status
+		if k8serrors.IsConflict(err) {
+			r.logger.Info("it seems someone update the status already")
+			return
+		}
+
 		if res.RequeueAfter == time.Duration(0) {
 			res.RequeueAfter = 1 * time.Second
 			r.logger.Error(err, fmt.Sprintf("failed to update status, will retry after %s", res.RequeueAfter))
@@ -770,4 +777,8 @@ func after(value string, a string) string {
 	}
 
 	return value[adjustedPos:]
+}
+
+func PrintHelper(o metav1.Object) types.NamespacedName {
+	return types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
 }


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

The last re-queue in hub tend to compete with some late resourceVersion, in this case, skip the requeue