### PR TITLE
convert placementrule CRD apiversion to v1beta1 for supporting <4.5 v…

### DIFF
--- a/deploy/crds/apps.open-cluster-management.io_subscriptions.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_subscriptions.yaml
@@ -11,6 +11,12 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
+  - JSONPath: .spec.placement.local
+    name: Local placement
+    type: boolean
+  - JSONPath: .spec.timewindow.windowtype
+    name: Time window
+    type: string
   conversion:
     strategy: None
   group: apps.open-cluster-management.io

--- a/deploy/crds/apps.open-cluster-management.io_subscriptions.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_subscriptions.yaml
@@ -1,13 +1,18 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-  creationTimestamp: null
   name: subscriptions.apps.open-cluster-management.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: subscription status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  conversion:
+    strategy: None
   group: apps.open-cluster-management.io
   names:
     kind: Subscription
@@ -16,312 +21,407 @@ spec:
     shortNames:
     - appsub
     singular: subscription
+  preserveUnknownFields: true
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: subscription status
-      jsonPath: .status.phase
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Subscription is the Schema for the subscriptions API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: SubscriptionSpec defines the desired state of Subscription
-            properties:
-              channel:
-                type: string
-              hooksecretref:
-                description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Subscription is the Schema for the subscriptions API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SubscriptionSpec defines the desired state of Subscription
+          properties:
+            channel:
+              type: string
+            hooksecretref:
+              description: 'ObjectReference contains enough information to let you
+                inspect or modify the referred object. --- New uses of this type are
+                discouraged because of difficulty describing its usage when embedded
+                in APIs.  1. Ignored fields.  It includes many fields which are not
+                generally honored.  For instance, ResourceVersion and FieldPath are
+                both very rarely valid in actual usage.  2. Invalid usage help.  It
+                is impossible to add specific help for individual usage.  In most
+                embedded usages, there are particular     restrictions like, "must
+                refer only to types A and B" or "UID not honored" or "name must be
+                restricted".     Those cannot be well described when embedded.  3.
+                Inconsistent validation.  Because the usages are different, the validation
+                rules are different by usage, which makes it hard for users to predict
+                what will happen.  4. The fields are both imprecise and overly precise.  Kind
+                is not a precise mapping to a URL. This can produce ambiguity     during
+                interpretation and require a REST mapping.  In most cases, the dependency
+                is on the group,resource tuple     and the version of the actual struct
+                is irrelevant.  5. We cannot easily change it.  Because this type
+                is embedded in many locations, updates to this type     will affect
+                numerous schemas.  Don''t make new APIs embed an underspecified API
+                type they do not control. Instead of using this type, create a locally
+                provided and used type that is well-focused on your reference. For
+                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                .'
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            name:
+              description: To specify 1 package in channel
+              type: string
+            overrides:
+              description: for hub use only to specify the overrides when apply to
+                clusters
+              items:
+                description: Overrides field in deployable
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
+                  clusterName:
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              name:
-                description: To specify 1 package in channel
-                type: string
-              overrides:
-                description: for hub use only to specify the overrides when apply to clusters
-                items:
-                  description: Overrides field in deployable
-                  properties:
-                    clusterName:
-                      type: string
-                    clusterOverrides:
-                      items:
-                        type: object
-                      minItems: 1
-                      type: array
-                  required:
-                  - clusterName
-                  - clusterOverrides
-                  type: object
-                type: array
-              packageFilter:
-                description: To specify more than 1 package in channel
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  filterRef:
-                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                    type: object
-                  labelSelector:
-                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  version:
-                    pattern: ([0-9]+)((\.[0-9]+)(\.[0-9]+)|(\.[0-9]+)?(\.[xX]))$
-                    type: string
-                type: object
-              packageOverrides:
-                description: To provide flexibility to override package in channel with local input
-                items:
-                  description: Overrides field in deployable
-                  properties:
-                    packageAlias:
-                      type: string
-                    packageName:
-                      type: string
-                    packageOverrides:
-                      items:
-                        type: object
-                      type: array
-                  required:
-                  - packageName
-                  type: object
-                type: array
-              placement:
-                description: For hub use only, to specify which clusters to go to
-                properties:
-                  clusterSelector:
-                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  clusters:
+                  clusterOverrides:
                     items:
-                      description: GenericClusterReference - in alignment with kubefed
-                      properties:
-                        name:
-                          type: string
-                      required:
-                      - name
+                      description: ClusterOverride describes rules for override
                       type: object
+                    minItems: 1
                     type: array
-                  local:
-                    type: boolean
-                  placementRef:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
+                required:
+                - clusterName
+                - clusterOverrides
                 type: object
-              timewindow:
-                description: help user control when the subscription will take affect
-                properties:
-                  daysofweek:
-                    description: weekdays defined the day of the week for this time window https://golang.org/pkg/time/#Weekday
-                    items:
-                      type: string
-                    type: array
-                  hours:
-                    items:
-                      description: HourRange time format for each time will be Kitchen format, defined at https://golang.org/pkg/time/#pkg-constants
-                      properties:
-                        end:
-                          type: string
-                        start:
-                          type: string
-                      type: object
-                    type: array
-                  location:
-                    description: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+              type: array
+            packageFilter:
+              description: To specify more than 1 package in channel
+              properties:
+                annotations:
+                  additionalProperties:
                     type: string
-                  windowtype:
-                    description: 'active time window or not, if timewindow is active, then deploy will only applies during these windows Note, if you want to generation crd with operator-sdk v0.10.0, then the following line should be: <+kubebuilder:validation:Enum=active,blocked,Active,Blocked>'
-                    enum:
-                    - active
-                    - blocked
-                    - Active
-                    - Blocked
-                    type: string
-                type: object
-            required:
-            - channel
-            type: object
-          status:
-            description: "SubscriptionStatus defines the observed state of Subscription Examples - status of a subscription on hub Status: \tphase: Propagated \tstatuses: \t  washdc: \t\tpackages: \t\t  nginx: \t\t\tphase: Subscribed \t\t  mongodb: \t\t\tphase: Failed \t\t\tReason: \"not authorized\" \t\t\tMessage: \"user xxx does not have permission to start pod\" \t\t\tresourceStatus: {}    toronto: \t\tpackages: \t\t  nginx: \t\t\tphase: Subscribed \t\t  mongodb: \t\t\tphase: Subscribed Status of a subscription on managed cluster will only have 1 cluster in the map."
-            properties:
-              ansiblejobs:
-                properties:
-                  lastposthookjob:
-                    type: string
-                  lastprehookjob:
-                    type: string
-                  posthookjobshistory:
-                    items:
-                      type: string
-                    type: array
-                  prehookjobshistory:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              lastUpdateTime:
-                format: date-time
-                type: string
-              message:
-                type: string
-              phase:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
-                type: string
-              reason:
-                type: string
-              statuses:
-                additionalProperties:
-                  description: SubscriptionPerClusterStatus defines status for subscription in each cluster, key is package name
+                  type: object
+                filterRef:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
-                    packages:
-                      additionalProperties:
-                        description: SubscriptionUnitStatus defines status of a unit (subscription or package)
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                labelSelector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
-                          lastUpdateTime:
-                            format: date-time
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
-                          message:
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
-                          phase:
-                            description: Phase are Propagated if it is in hub or Subscribed if it is in endpoint
-                            type: string
-                          reason:
-                            type: string
-                          resourceStatus:
-                            type: object
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
                         required:
-                        - lastUpdateTime
+                        - key
+                        - operator
                         type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
-                description: For endpoint, it is the status of subscription, key is packagename, For hub, it aggregates all status, key is cluster name
+                version:
+                  pattern: ([0-9]+)((\.[0-9]+)(\.[0-9]+)|(\.[0-9]+)?(\.[xX]))$
+                  type: string
+              type: object
+            packageOverrides:
+              description: To provide flexibility to override package in channel with
+                local input
+              items:
+                description: Overrides field in deployable
+                properties:
+                  packageAlias:
+                    type: string
+                  packageName:
+                    type: string
+                  packageOverrides:
+                    items:
+                      description: PackageOverride describes rules for override
+                      type: object
+                    type: array
+                required:
+                - packageName
                 type: object
-            type: object
-        type: object
+              type: array
+            placement:
+              description: For hub use only, to specify which clusters to go to
+              properties:
+                clusterSelector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    description: GenericClusterReference - in alignment with kubefed
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                local:
+                  type: boolean
+                placementRef:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              type: object
+            timewindow:
+              description: help user control when the subscription will take affect
+              properties:
+                daysofweek:
+                  description: weekdays defined the day of the week for this time
+                    window https://golang.org/pkg/time/#Weekday
+                  items:
+                    type: string
+                  type: array
+                hours:
+                  items:
+                    description: HourRange time format for each time will be Kitchen
+                      format, defined at https://golang.org/pkg/time/#pkg-constants
+                    properties:
+                      end:
+                        type: string
+                      start:
+                        type: string
+                    type: object
+                  type: array
+                location:
+                  description: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+                  type: string
+                windowtype:
+                  description: 'active time window or not, if timewindow is active,
+                    then deploy will only applies during these windows Note, if you
+                    want to generation crd with operator-sdk v0.10.0, then the following
+                    line should be: <+kubebuilder:validation:Enum=active,blocked,Active,Blocked>'
+                  enum:
+                  - active
+                  - blocked
+                  - Active
+                  - Blocked
+                  type: string
+              type: object
+          required:
+          - channel
+          type: object
+        status:
+          description: "SubscriptionStatus defines the observed state of Subscription
+            Examples - status of a subscription on hub Status: \tphase: Propagated
+            \tstatuses: \t  washdc: \t\tpackages: \t\t  nginx: \t\t\tphase: Subscribed
+            \t\t  mongodb: \t\t\tphase: Failed \t\t\tReason: \"not authorized\" \t\t\tMessage:
+            \"user xxx does not have permission to start pod\" \t\t\tresourceStatus:
+            {}    toronto: \t\tpackages: \t\t  nginx: \t\t\tphase: Subscribed \t\t
+            \ mongodb: \t\t\tphase: Subscribed Status of a subscription on managed
+            cluster will only have 1 cluster in the map."
+          properties:
+            ansiblejobs:
+              properties:
+                lastposthookjob:
+                  type: string
+                lastprehookjob:
+                  type: string
+                posthookjobshistory:
+                  items:
+                    type: string
+                  type: array
+                prehookjobshistory:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            lastUpdateTime:
+              format: date-time
+              type: string
+            message:
+              type: string
+            phase:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              type: string
+            reason:
+              type: string
+            statuses:
+              additionalProperties:
+                description: SubscriptionPerClusterStatus defines status for subscription
+                  in each cluster, key is package name
+                properties:
+                  packages:
+                    additionalProperties:
+                      description: SubscriptionUnitStatus defines status of a unit
+                        (subscription or package)
+                      properties:
+                        lastUpdateTime:
+                          format: date-time
+                          type: string
+                        message:
+                          type: string
+                        phase:
+                          description: Phase are Propagated if it is in hub or Subscribed
+                            if it is in endpoint
+                          type: string
+                        reason:
+                          type: string
+                        resourceStatus:
+                          type: object
+                      required:
+                      - lastUpdateTime
+                      type: object
+                    type: object
+                type: object
+              description: For endpoint, it is the status of subscription, key is
+                packagename, For hub, it aggregates all status, key is cluster name
+              type: object
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
     served: true
     storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -242,6 +242,8 @@ type SubscriptionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="subscription status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Local placement",type="boolean",JSONPath=".spec.placement.local"
+// +kubebuilder:printcolumn:name="Time window",type="string",JSONPath=".spec.timewindow.windowtype"
 // +kubebuilder:resource:shortName=appsub
 type Subscription struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
…ersions of OCP

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The apiVersion of the `kind:CustomResourceDefinition` in all of our CRDs  has to be `v1beta1` for backporting <4.5 versions of OCP.  Or the CRD will fail to be applied to OCP <4.5.  OCP 4.4 is still supported by ACM. 

```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
```
Please note our appsub CRDs version are still remained as V1 
```
apiVersion: apps.open-cluster-management.io/v1
kind: Subscription
