### PR TITLE
make sure the applied jobs is updated to topo annotation

### DIFF
--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -17,6 +17,7 @@ package mcmhub
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -517,10 +518,16 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 
 			updateStatus := updateSub.Status.AnsibleJobsStatus
 
+			an := updateSub.GetAnnotations()[subv1.AnnotationTopo]
+
 			dErr := fmt.Errorf("failed to get ansiblejob status %s, %#v", subKey, updateStatus)
 
 			if len(updateStatus.PosthookJobsHistory) < 2 {
 				return dErr
+			}
+
+			if !strings.Contains(an, updateStatus.LastPosthookJob) {
+				return fmt.Errorf("the last applied hook is not in topo annotation")
 			}
 
 			return nil


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Addressing [issue](https://github.com/open-cluster-management/backlog/issues/5743)

Basically, when a new hook instance is generated, we want to make sure the topo annotation update logic is triggered.