### PR TITLE
[WIP] adding gitwatch on hub for hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.5
 	github.com/google/go-cmp v0.5.1
-	github.com/google/go-github/v28 v28.1.1
+	github.com/google/go-github/v32 v32.1.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20200218152459-de0855a40bc1
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,8 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -224,7 +224,7 @@ func (a *AnsibleHooks) RegisterSubscription(subKey types.NamespacedName, forceRe
 
 	//if not forcing a register and the subIns has not being changed compare to the hook registry
 	//then skip hook processing
-	if !forceRegister && !a.isSubscriptionUpdate(subIns, a.isSubscriptionSpecChange) {
+	if !forceRegister && !a.isSubscriptionUpdate(subIns, a.isSubscriptionSpecChange, isCommitIDNotEqual) {
 		return nil
 	}
 

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -429,7 +429,7 @@ func (a *AnsibleHooks) isSubscriptionUpdate(subIns *subv1.Subscription, isNotEqu
 	}
 
 	for _, eFn := range isNotEqual {
-		if !eFn(record.lastSub, subIns) {
+		if eFn(record.lastSub, subIns) {
 			return true
 		}
 	}
@@ -439,6 +439,10 @@ func (a *AnsibleHooks) isSubscriptionUpdate(subIns *subv1.Subscription, isNotEqu
 
 func isCommitIDNotEqual(a, b *subv1.Subscription) bool {
 	aCommit := getCommitID(a)
+	if aCommit == "" {
+		return false
+	}
+
 	bCommit := getCommitID(b)
 
 	return aCommit != bCommit

--- a/pkg/controller/mcmhub/hook_git.go
+++ b/pkg/controller/mcmhub/hook_git.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
@@ -66,11 +65,13 @@ func NewHookGit(clt client.Client, logger logr.Logger) *HookGit {
 // the git watch will go to each subscription download the repo and compare the
 // commit id, it's the commit id is different, then update the commit id to
 // subscription
-func (a *AnsibleHooks) StartGitWatch(interval time.Duration, stop <-chan struct{}) {
+func (a *AnsibleHooks) Start(stop <-chan struct{}) error {
 	a.logger.Info("entry StartGitWatch")
 	defer a.logger.Info("exit StartGitWatch")
 
-	go wait.Until(a.GitWatch, interval, stop)
+	go wait.Until(a.GitWatch, a.hookInterval, stop)
+
+	return nil
 }
 
 func (a *AnsibleHooks) GitWatch() {

--- a/pkg/controller/mcmhub/hook_git.go
+++ b/pkg/controller/mcmhub/hook_git.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
@@ -33,6 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hookInterval = time.Minute * 1
 )
 
 type GitOps interface {
@@ -69,7 +74,7 @@ func (a *AnsibleHooks) Start(stop <-chan struct{}) error {
 	a.logger.Info("entry StartGitWatch")
 	defer a.logger.Info("exit StartGitWatch")
 
-	go wait.Until(a.GitWatch, a.hookInterval, stop)
+	go wait.Until(a.GitWatch, hookInterval, stop)
 
 	return nil
 }

--- a/pkg/controller/mcmhub/hook_git.go
+++ b/pkg/controller/mcmhub/hook_git.go
@@ -21,14 +21,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
+	"github.com/google/go-github/v32/github"
 	ansiblejob "github.com/open-cluster-management/ansiblejob-go-lib/api/v1alpha1"
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	subv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,6 +61,102 @@ func NewHookGit(clt client.Client, logger logr.Logger) *HookGit {
 		logger:       logger,
 		lastCommitID: make(map[types.NamespacedName]string),
 	}
+}
+
+// the git watch will go to each subscription download the repo and compare the
+// commit id, it's the commit id is different, then update the commit id to
+// subscription
+func (a *AnsibleHooks) StartGitWatch(interval time.Duration, stop <-chan struct{}) {
+	a.logger.Info("entry StartGitWatch")
+	defer a.logger.Info("exit StartGitWatch")
+
+	go wait.Until(a.GitWatch, interval, stop)
+}
+
+func (a *AnsibleHooks) GitWatch() {
+	a.logger.V(DebugLog).Info("entry GitWatch")
+	defer a.logger.V(DebugLog).Info("exit GitWatch")
+
+	ctx := context.TODO()
+
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	for subKey := range a.registry {
+		subIns := &subv1.Subscription{}
+		if err := a.clt.Get(ctx, subKey, subIns); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				a.logger.Error(err, "failed to get ")
+			}
+
+			continue
+		}
+
+		if newCommit, ok := a.IsGitUpdate(subIns); ok {
+			anno := subIns.GetAnnotations()
+			anno[subv1.AnnotationGitCommit] = newCommit
+			subIns.SetAnnotations(anno)
+
+			if err := a.clt.Update(ctx, subIns); err != nil {
+				a.logger.Error(err, "failed to update subscription from GitWatch")
+			}
+
+			a.logger.Info(fmt.Sprintf("updated the commit annotation of subscrption %s", subKey))
+		}
+	}
+}
+
+func (a *AnsibleHooks) IsGitUpdate(nSubIns *subv1.Subscription) (string, bool) {
+	subKey := types.NamespacedName{Name: nSubIns.GetName(), Namespace: nSubIns.GetNamespace()}
+	oldCommit := nSubIns.GetAnnotations()[subv1.AnnotationGitCommit]
+	newCommit, err := GetLatestRemoteGitCommitID(a.clt, nSubIns)
+
+	if err != nil {
+		a.logger.Error(err, fmt.Sprintf("failed to get the new commit id for subscription %s", subKey))
+		return "", false
+	}
+
+	if !strings.EqualFold(oldCommit, newCommit) {
+		return newCommit, true
+	}
+
+	return "", false
+}
+
+func GetLatestRemoteGitCommitID(clt client.Client, subIns *subv1.Subscription) (string, error) {
+	channel, err := GetSubscriptionRefChannel(clt, subIns)
+
+	if err != nil {
+		return "", err
+	}
+
+	user, pwd, err := utils.GetChannelSecret(clt, channel)
+
+	if err != nil {
+		return "", err
+	}
+
+	an := subIns.GetAnnotations()
+
+	branch := ""
+	if an[subv1.AnnotationGithubBranch] != "" {
+		branch = an[subv1.AnnotationGithubBranch]
+	}
+
+	if an[subv1.AnnotationGitBranch] != "" {
+		branch = an[subv1.AnnotationGitBranch]
+	}
+
+	if branch == "" {
+		branch = "master"
+	}
+
+	tp := github.BasicAuthTransport{
+		Username: strings.TrimSpace(user),
+		Password: strings.TrimSpace(pwd),
+	}
+
+	return utils.GetLatestCommitID(channel.Spec.Pathname, branch, github.NewClient(tp.Client()))
 }
 
 func (h *HookGit) DownloadAnsibleHookResource(subIns *subv1.Subscription) error {

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -401,7 +401,7 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 		ctx      = context.TODO()
 	)
 
-	FIt("upon the change of a subscription, it should create 2nd ansiblejob instance for hook(s)", func() {
+	It("upon the change of a subscription, it should create 2nd ansiblejob instance for hook(s)", func() {
 		subIns := testPath.subIns.DeepCopy()
 		chnIns := testPath.chnIns.DeepCopy()
 

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -400,7 +400,7 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 		ctx      = context.TODO()
 	)
 
-	It("upon the change of a subscription, it should create 2nd ansiblejob instance for hook(s)", func() {
+	FIt("upon the change of a subscription, it should create 2nd ansiblejob instance for hook(s)", func() {
 		subIns := testPath.subIns.DeepCopy()
 		chnIns := testPath.chnIns.DeepCopy()
 

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -431,7 +431,7 @@ func (r *ReconcileSubscription) GetChannelNamespaceType(s *appv1alpha1.Subscript
 	return chNameSpace, chName, chType
 }
 
-func (r *ReconcileSubscription) getChannel(s *appv1alpha1.Subscription) (*chnv1alpha1.Channel, error) {
+func GetSubscriptionRefChannel(clt client.Client, s *appv1.Subscription) (*chnv1.Channel, error) {
 	chNameSpace := ""
 	chName := ""
 
@@ -445,7 +445,7 @@ func (r *ReconcileSubscription) getChannel(s *appv1alpha1.Subscription) (*chnv1a
 
 	chkey := types.NamespacedName{Name: chName, Namespace: chNameSpace}
 	chobj := &chnv1.Channel{}
-	err := r.Get(context.TODO(), chkey, chobj)
+	err := clt.Get(context.TODO(), chkey, chobj)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -455,6 +455,10 @@ func (r *ReconcileSubscription) getChannel(s *appv1alpha1.Subscription) (*chnv1a
 	}
 
 	return chobj, err
+}
+
+func (r *ReconcileSubscription) getChannel(s *appv1alpha1.Subscription) (*chnv1alpha1.Channel, error) {
+	return GetSubscriptionRefChannel(r.Client, s)
 }
 
 // GetChannelGeneration get the channel generation

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -34,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -86,6 +89,29 @@ const (
 * business logic.  Delete these comments after modifying this file.*
  */
 
+var onlyOneGitWatcherSignalHandler = make(chan struct{})
+var gitShutdownSignals = []os.Signal{os.Interrupt}
+
+// SetupSignalHandler registers for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupGitWatcherSignalHandler() (stopCh <-chan struct{}) {
+	close(onlyOneGitWatcherSignalHandler) // panics when called twice
+
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, gitShutdownSignals...)
+
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}
+
 // Add creates a new Subscription Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -114,6 +140,8 @@ func newReconciler(mgr manager.Manager, op ...Option) reconcile.Reconciler {
 	for _, f := range op {
 		f(rec)
 	}
+
+	rec.hooks.StartGitWatch(rec.hookRequeueInterval, SetupGitWatcherSignalHandler())
 
 	return rec
 }

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -112,7 +112,7 @@ func newReconciler(mgr manager.Manager, op ...Option) reconcile.Reconciler {
 	}
 
 	//this is used to start up the git watcher
-	//mgr.Add(rec.hooks)
+	mgr.Add(rec.hooks)
 
 	return rec
 }

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -112,7 +112,9 @@ func newReconciler(mgr manager.Manager, op ...Option) reconcile.Reconciler {
 	}
 
 	//this is used to start up the git watcher
-	mgr.Add(rec.hooks)
+	if err := mgr.Add(rec.hooks); err != nil {
+		logger.Error(err, "failed to start git watcher")
+	}
 
 	return rec
 }

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -111,9 +111,9 @@ func newReconciler(mgr manager.Manager, op ...Option) reconcile.Reconciler {
 		f(rec)
 	}
 
-	mgr.Add(rec.hooks)
+	//this is used to start up the git watcher
+	//mgr.Add(rec.hooks)
 
-	fmt.Println("izhang newReconciler")
 	return rec
 }
 

--- a/pkg/webhook/listener/github_events.go
+++ b/pkg/webhook/listener/github_events.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v28/github"
+	"github.com/google/go-github/v32/github"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Fix git change flow of [issue](https://github.com/open-cluster-management/backlog/issues/5743#issuecomment-700291030)

With this fix, when the git commits changes, the `GitWatcher` will update the commitID annotation of the subscription, which will trigger the instance to reconcile and update the hook instance.