### PR TITLE
fix managed cluster status update

### DIFF
--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -777,8 +777,8 @@ func (r *ReconcileSubscription) updateSubAnnotations(sub *appv1alpha1.Subscripti
 }
 
 func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscription, found *dplv1alpha1.Deployable, chn *chnv1alpha1.Channel) error {
-	r.logger.Info("entry doMCMHubReconcile:updateSubscriptionStatus")
-	defer r.logger.Info("exit doMCMHubReconcile:updateSubscriptionStatus")
+	r.logger.Info(fmt.Sprintf("entry doMCMHubReconcile:updateSubscriptionStatus %s", PrintHelper(sub)))
+	defer r.logger.Info(fmt.Sprintf("exit doMCMHubReconcile:updateSubscriptionStatus %s", PrintHelper(sub)))
 
 	newsubstatus := appv1alpha1.SubscriptionStatus{}
 

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -794,7 +794,6 @@ func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscr
 		newsubstatus.Statuses = make(map[string]*appv1alpha1.SubscriptionPerClusterStatus)
 
 		for cluster, cstatus := range found.Status.PropagatedStatus {
-
 			clusterSubStatus := &appv1alpha1.SubscriptionPerClusterStatus{}
 			subPkgStatus := make(map[string]*appv1alpha1.SubscriptionUnitStatus)
 

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -794,11 +794,6 @@ func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscr
 		newsubstatus.Statuses = make(map[string]*appv1alpha1.SubscriptionPerClusterStatus)
 
 		for cluster, cstatus := range found.Status.PropagatedStatus {
-			if msg == "" {
-				msg = fmt.Sprintf("%s:%s", cluster, cstatus.Message)
-			} else {
-				msg += fmt.Sprintf(",%s:%s", cluster, cstatus.Message)
-			}
 
 			clusterSubStatus := &appv1alpha1.SubscriptionPerClusterStatus{}
 			subPkgStatus := make(map[string]*appv1alpha1.SubscriptionUnitStatus)
@@ -809,6 +804,12 @@ func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscr
 				if err != nil {
 					klog.Infof("Failed to unmashall ResourceStatus from target cluster: %v, in deployable: %v/%v", cluster, found.GetNamespace(), found.GetName())
 					return err
+				}
+
+				if msg == "" {
+					msg = fmt.Sprintf("%s:%s", cluster, mcsubstatus.Message)
+				} else {
+					msg += fmt.Sprintf(",%s:%s", cluster, mcsubstatus.Message)
 				}
 
 				//get status per package if exist, for namespace/objectStore/helmRepo channel subscription status

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -415,7 +415,11 @@ func (r *ReconcileSubscription) setHubSubscriptionStatus(sub *appv1.Subscription
 
 	if err == nil {
 		sub.Status.Reason = hubdpl.Status.Reason
-		sub.Status.Message = hubdpl.Status.Message
+
+		// the sub.Status.Message is aggregated over the doMCMHubReconcile
+		if sub.Status.Message == "" {
+			sub.Status.Message = hubdpl.Status.Message
+		}
 
 		if hubdpl.Status.Phase == dplv1.DeployableFailed {
 			sub.Status.Phase = appv1.SubscriptionPropagationFailed

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -161,7 +161,7 @@ func (mapper *subscriptionMapper) Map(obj handler.MapObject) []reconcile.Request
 		}
 
 		if annotations[appv1.AnnotationRollingUpdateTarget] != obj.Meta.GetName() {
-			// rolling to annother one, skipping
+			// rolling to another one, skipping
 			continue
 		}
 
@@ -694,8 +694,8 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 			return
 		}
 
-		// due to the predict func, it's nesseccery to requeue, since the status
-		// change isn't commited yet
+		// due to the predict func, it's necessary to re-queue, since the status
+		// change isn't committed yet
 		if res.RequeueAfter == time.Duration(0) {
 			res.RequeueAfter = 5 * time.Second
 			r.logger.Info(fmt.Sprintf("%s on prehook topo annotation flow, will retry after %s", PrintHelper(nIns), res.RequeueAfter))
@@ -706,7 +706,6 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 
 	//update status early to make sure the status is ready for post hook to
 	//consume
-
 	if !passedPrehook {
 		nIns.Status.Phase = appv1.SubscriptionPropagationFailed
 		nIns.Status.Reason = preErr.Error()

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -694,11 +694,11 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 			return
 		}
 
-		if !passedPrehook { //prehook prior to apply successed
-			if res.RequeueAfter == time.Duration(0) {
-				res.RequeueAfter = 5 * time.Second
-				r.logger.Info(fmt.Sprintf("on prehook topo annotation flow, will retry after %s", res.RequeueAfter))
-			}
+		// due to the predict func, it's nesseccery to requeue, since the status
+		// change isn't commited yet
+		if res.RequeueAfter == time.Duration(0) {
+			res.RequeueAfter = 5 * time.Second
+			r.logger.Info(fmt.Sprintf("%s on prehook topo annotation flow, will retry after %s", PrintHelper(nIns), res.RequeueAfter))
 		}
 
 		return

--- a/pkg/synchronizer/kubernetes/extension.go
+++ b/pkg/synchronizer/kubernetes/extension.go
@@ -95,12 +95,12 @@ func (se *SubscriptionExtension) updateHostDeployable(local, remote client.Clien
 	host := utils.GetHostDeployableFromObject(subIns)
 
 	if host == nil {
-		klog.Info("Failed to find hosting deployable for ", subIns)
+		klog.V(2).Info("Failed to find hosting deployable for ", subIns)
 		return nil
 	}
 
 	if host.String() == "/" {
-		klog.Info("host is not hub deployable, skip this deployable override")
+		klog.V(2).Info("host is not hub deployable, skip this deployable override")
 		return nil
 	}
 

--- a/pkg/synchronizer/kubernetes/extension.go
+++ b/pkg/synchronizer/kubernetes/extension.go
@@ -58,10 +58,12 @@ var (
 // UpdateHostSubscriptionStatus defines update host status function for deployable
 func (se *SubscriptionExtension) UpdateHostStatus(actionerr error, tplunit *unstructured.Unstructured, status interface{}, deletePkg bool) error {
 	host := se.GetHostFromObject(tplunit)
+	// the tplunit is the root subscription on managed cluster
 	if host == nil || host.String() == "/" {
 		return utils.UpdateDeployableStatus(se.remoteClient, actionerr, tplunit, status)
 	}
 
+	//update managed cluster subscription status
 	return utils.UpdateSubscriptionStatus(se.localClient, actionerr, tplunit, status, deletePkg)
 }
 

--- a/pkg/synchronizer/kubernetes/extension.go
+++ b/pkg/synchronizer/kubernetes/extension.go
@@ -99,6 +99,11 @@ func (se *SubscriptionExtension) updateHostDeployable(local, remote client.Clien
 		return nil
 	}
 
+	if host.String() == "/" {
+		klog.Info("host is not hub deployable, skip this deployable override")
+		return nil
+	}
+
 	return utils.UpdateDeployableStatus(remote, actionerr, subIns, subIns.Status)
 }
 

--- a/pkg/utils/deployable.go
+++ b/pkg/utils/deployable.go
@@ -179,11 +179,9 @@ func UpdateDeployableStatus(statusClient client.Client, templateerr error, tplun
 
 	klog.V(1).Infof("old old: %#v, in in:%#v", *oldStatus, newStatus)
 
-
 	fmt.Println(isEmptyResourceUnitStatus(newStatus.ResourceUnitStatus), isManagedStatusUpdated(*oldStatus, newStatus))
 
 	if isEmptyResourceUnitStatus(newStatus.ResourceUnitStatus) || isManagedStatusUpdated(*oldStatus, newStatus) {
-
 		statuStr := fmt.Sprintf("updating old %s, new %s", prettyStatus(dpl.Status), prettyStatus(newStatus))
 		klog.Info(fmt.Sprintf("host %s cmp status %s ", host.String(), statuStr))
 
@@ -273,7 +271,6 @@ func isSubscriptionResourceStatusUpdated(a, b dplv1.ResourceUnitStatus) bool {
 		return true
 	}
 
-
 	klog.V(1).Infof("aUnitStatus: %#v, bUnitStatus: %#v", aUnitStatus, bUnitStatus)
 
 	now := metav1.Now()
@@ -296,21 +293,24 @@ func PrintSubscriptionStatus(a *subv1.SubscriptionStatus) {
 
 	for c, clusterStatus := range a.Statuses {
 		fmt.Printf("cluster name = %+v\n", c)
+
 		for n, p := range clusterStatus.SubscriptionPackageStatus {
 			fmt.Println()
+
 			if p == nil {
 				continue
 			}
+
 			fmt.Printf("\tpkg name %s\n", n)
 			fmt.Printf("\tpkg package phase %s\n", p.Phase)
 			fmt.Printf("\tpkg package message %s\n", p.Message)
 			fmt.Printf("\tpkg package reason %s\n", p.Reason)
+
 			if p.ResourceStatus == nil {
 				continue
 			}
 
 			fmt.Printf("\tpkg package content %s\n", string(p.ResourceStatus.Raw))
-
 		}
 
 		fmt.Println()

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -146,7 +146,6 @@ func FilterOutTimeRelatedFields(in *appv1.Subscription) *appv1.Subscription {
 }
 
 func IsHubRelatedStatusChanged(old, nnew *appv1.SubscriptionStatus) bool {
-	// care about certain ansiblejob field
 	if !isAnsibleStatusEqual(old.AnsibleJobsStatus, nnew.AnsibleJobsStatus) {
 		return true
 	}
@@ -156,7 +155,7 @@ func IsHubRelatedStatusChanged(old, nnew *appv1.SubscriptionStatus) bool {
 	}
 
 	//care about the managed subscription status
-	if !reflect.DeepEqual(old.Statuses, nnew.Statuses) {
+	if !isEqualSubscriptionStatus(old, nnew) {
 		return true
 	}
 
@@ -370,6 +369,7 @@ func isEmptySubscriptionStatus(a *appv1.SubscriptionStatus) bool {
 }
 
 func IsEqualSubScriptionStatus(o, n *appv1.SubscriptionStatus) bool {
+	fmt.Printf("izhang ----hub aaa  o = %+v\n n = %#v\n", o, n)
 	return isEqualSubscriptionStatus(o, n)
 }
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -407,7 +407,17 @@ func isEqualSubClusterStatus(a, b map[string]*appv1.SubscriptionPerClusterStatus
 	}
 
 	for k, v := range a {
-		if w, ok := b[k]; !ok || !isEqualSubPerClusterStatus(v.SubscriptionPackageStatus, w.SubscriptionPackageStatus) {
+		if w, ok := b[k]; ok {
+			if v == nil && w == nil {
+				continue
+			}
+
+			if v != nil && w != nil && isEqualSubPerClusterStatus(v.SubscriptionPackageStatus, w.SubscriptionPackageStatus) {
+				continue
+			}
+
+			return false
+		} else { //key not in the b.Statuses
 			return false
 		}
 	}

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -146,11 +146,17 @@ func FilterOutTimeRelatedFields(in *appv1.Subscription) *appv1.Subscription {
 }
 
 func IsHubRelatedStatusChanged(old, nnew *appv1.SubscriptionStatus) bool {
+	// care about certain ansiblejob field
 	if !isAnsibleStatusEqual(old.AnsibleJobsStatus, nnew.AnsibleJobsStatus) {
 		return true
 	}
 
 	if old.Phase != nnew.Phase {
+		return true
+	}
+
+	//care about the managed subscription status
+	if !reflect.DeepEqual(old.Statuses, nnew.Statuses) {
 		return true
 	}
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -150,12 +150,12 @@ func IsHubRelatedStatusChanged(old, nnew *appv1.SubscriptionStatus) bool {
 		return true
 	}
 
-	if old.Phase != nnew.Phase {
+	if old.Phase != nnew.Phase || old.Message != nnew.Message {
 		return true
 	}
 
 	//care about the managed subscription status
-	if !isEqualSubscriptionStatus(old, nnew) {
+	if !isEqualSubClusterStatus(old.Statuses, nnew.Statuses) {
 		return true
 	}
 
@@ -369,7 +369,6 @@ func isEmptySubscriptionStatus(a *appv1.SubscriptionStatus) bool {
 }
 
 func IsEqualSubScriptionStatus(o, n *appv1.SubscriptionStatus) bool {
-	fmt.Printf("izhang ----hub aaa  o = %+v\n n = %#v\n", o, n)
 	return isEqualSubscriptionStatus(o, n)
 }
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -407,7 +407,8 @@ func isEqualSubClusterStatus(a, b map[string]*appv1.SubscriptionPerClusterStatus
 	}
 
 	for k, v := range a {
-		if w, ok := b[k]; ok {
+		w, ok := b[k]
+		if ok {
 			if v == nil && w == nil {
 				continue
 			}
@@ -417,9 +418,9 @@ func isEqualSubClusterStatus(a, b map[string]*appv1.SubscriptionPerClusterStatus
 			}
 
 			return false
-		} else { //key not in the b.Statuses
-			return false
 		}
+
+		return false
 	}
 
 	return true

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -151,7 +151,7 @@ var _ = Describe("subscription(s)", func() {
 			// extra package info
 			a.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{},
+					"cfg": {},
 				},
 			}
 
@@ -159,14 +159,14 @@ var _ = Describe("subscription(s)", func() {
 
 			b.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{},
+					"cfg": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).Should(BeTrue())
 
 			a.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:  "a",
 						Reason: "ab",
 					},
@@ -177,7 +177,7 @@ var _ = Describe("subscription(s)", func() {
 
 			b.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:  "a",
 						Reason: "ab",
 					},
@@ -188,11 +188,11 @@ var _ = Describe("subscription(s)", func() {
 			// having extra package
 			a.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:  "a",
 						Reason: "ab",
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).ShouldNot(BeTrue())
@@ -200,12 +200,12 @@ var _ = Describe("subscription(s)", func() {
 			//should ignore the package level LastUpdateTime
 			b.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:          "a",
 						Reason:         "ab",
 						LastUpdateTime: metav1.Now(),
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).Should(BeTrue())
@@ -213,52 +213,52 @@ var _ = Describe("subscription(s)", func() {
 			// having extra package raw data
 			a.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:          "a",
 						Reason:         "ab",
 						ResourceStatus: &runtime.RawExtension{},
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).ShouldNot(BeTrue())
 
 			b.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:          "a",
 						Reason:         "ab",
 						ResourceStatus: &runtime.RawExtension{},
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).Should(BeTrue())
 
 			a.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:  "a",
 						Reason: "ab",
 						ResourceStatus: &runtime.RawExtension{
 							Raw: []byte("ad,12"),
 						},
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).ShouldNot(BeTrue())
 
 			b.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:  "a",
 						Reason: "ab",
 						ResourceStatus: &runtime.RawExtension{
 							Raw: []byte("ad,12"),
 						},
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).Should(BeTrue())
@@ -266,14 +266,14 @@ var _ = Describe("subscription(s)", func() {
 			//check the reflect.DeepEqual logic on the ResourceStatus
 			b.Statuses["/"] = &appv1.SubscriptionPerClusterStatus{
 				SubscriptionPackageStatus: map[string]*appv1.SubscriptionUnitStatus{
-					"cfg": &appv1.SubscriptionUnitStatus{
+					"cfg": {
 						Phase:  "a",
 						Reason: "ab",
 						ResourceStatus: &runtime.RawExtension{
 							Raw: []byte("ad,123"),
 						},
 					},
-					"srt": &appv1.SubscriptionUnitStatus{},
+					"srt": {},
 				},
 			}
 			Expect(isEqualSubscriptionStatus(a, b)).ShouldNot(BeTrue())


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Addressing [issue](https://app.zenhub.com/workspaces/applifecycle-issue-tracker-5e480a1f17e47394a67447b9/issues/open-cluster-management/backlog/5887)

@xiangjingli  this one should fix the status update from the managed cluster to hub.

https://github.com/open-cluster-management/multicloud-operators-subscription/compare/issue-5887?expand=1#diff-54df3d0f5d9d5161cc520b082ec0ec8bL259

^ is the reason why the update failed since the `ResourceStatus` is actually `SubscriptionStatus`, which means the Unmarshal will lose most of the info and leads to false positive of the comparison func.

Not sure if the Unmarshal to `SubscriptionStatus` would cover all cases tho, please advise.
