### PR TITLE
fix the git watcher

### DIFF
--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -69,6 +69,7 @@ func (jIns *JobInstances) registryJobs(subIns *subv1.Subscription, suffixFunc Su
 
 		nx := ins.DeepCopy()
 		suffix := suffixFunc(subIns)
+
 		if suffix == "" {
 			continue
 		}

--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -67,12 +67,15 @@ func (jIns *JobInstances) registryJobs(subIns *subv1.Subscription, suffixFunc Su
 			}
 		}
 
+		nx := ins.DeepCopy()
+		suffix := suffixFunc(subIns)
+		if suffix == "" {
+			continue
+		}
+
 		jobRecords := (*jIns)[jobKey]
 		jobRecords.mux.Lock()
 		jobRecords.Original = ins
-
-		nx := ins.DeepCopy()
-		suffix := suffixFunc(subIns)
 
 		if forceRegister {
 			plrSuffixFunc := func() string {

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -79,7 +79,7 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 		}
 
 		//making sure the commit id is coming from the same source
-		getCommitFunc := r.hubGitOps.GetCommitFunc()
+		getCommitFunc := r.hubGitOps.GetCommitFunc(sub)
 		commit, err := getCommitFunc(channel.Spec.Pathname,
 			genBranchString(sub),
 			user,

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -78,11 +78,13 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 			return false, err
 		}
 
-		commit, err := utils.CloneGitRepo(channel.Spec.Pathname,
-			utils.GetSubscriptionBranch(sub),
+		//making sure the commit id is coming from the same source
+		getCommitFunc := r.hubGitOps.GetCommitFunc()
+		commit, err := getCommitFunc(channel.Spec.Pathname,
+			genBranchString(sub),
 			user,
 			pwd,
-			utils.GetLocalGitFolder(channel, sub))
+		)
 
 		if err != nil {
 			klog.Error(err.Error())

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -71,21 +71,8 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 	if utils.IsGitChannel(string(channel.Spec.Type)) {
 		klog.Infof("Subscription %s has Git type channel.", sub.GetName())
 
-		user, pwd, err := utils.GetChannelSecret(r.Client, channel)
-
-		if err != nil {
-			klog.Errorf("Failed to get secret for channel: %s", channel.GetName())
-			return false, err
-		}
-
 		//making sure the commit id is coming from the same source
-		getCommitFunc := r.hubGitOps.GetCommitFunc(sub)
-		commit, err := getCommitFunc(channel.Spec.Pathname,
-			genBranchString(sub),
-			user,
-			pwd,
-		)
-
+		commit, err := r.hubGitOps.GetLatestCommitID(sub)
 		if err != nil {
 			klog.Error(err.Error())
 			return false, err

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -263,6 +263,7 @@ type SuffixFunc func(*subv1.Subscription) string
 func suffixBasedOnSpecAndCommitID(subIns *subv1.Subscription) string {
 	commitID := getCommitID(subIns)
 	n := len(commitID)
+
 	if n == 0 { // meaning the commitID is not synced with github
 		return ""
 	}

--- a/pkg/controller/mcmhub/hook_git_test.go
+++ b/pkg/controller/mcmhub/hook_git_test.go
@@ -1,0 +1,243 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcmhub
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
+	plrv1alpha1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	subv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func checkGitRegCommit(tbranch string) func() error {
+	return func() error {
+		rr := gitOps.GetRepoRecords()
+
+		branchInfo := rr[ansibleGitURL].branchs[tbranch]
+		if strings.EqualFold(branchInfo.lastCommitID, defaultCommit) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to get the update commit ID from the git registry")
+	}
+}
+
+func registerSub(key types.NamespacedName) func() error {
+	ctx := context.TODO()
+
+	return func() error {
+		u := &subv1.Subscription{}
+
+		if err := k8sClt.Get(ctx, key, u); err != nil {
+			return err
+		}
+
+		gitOps.RegisterBranch(u)
+
+		return nil
+	}
+}
+
+func deRegisterSub(key types.NamespacedName) func() error {
+	return func() error {
+		gitOps.DeregisterBranch(key)
+
+		return nil
+	}
+}
+
+var _ = Describe("git ops", func() {
+	var (
+		ctx    = context.TODO()
+		testNs = "t-ns-gitops"
+
+		dSubKey = types.NamespacedName{Name: "t-sub-git-ops", Namespace: testNs}
+		chnKey  = types.NamespacedName{Name: "t-chn-git-ops", Namespace: testNs}
+
+		chnIns = &chnv1.Channel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      chnKey.Name,
+				Namespace: chnKey.Namespace,
+			},
+			Spec: chnv1.ChannelSpec{
+				Pathname: ansibleGitURL,
+				Type:     chnv1.ChannelTypeGit,
+			},
+		}
+
+		subIns = &subv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dSubKey.Name,
+				Namespace: dSubKey.Namespace,
+				Annotations: map[string]string{
+					subv1.AnnotationGitPath: "test/hooks/ansible/pre-and-post",
+				},
+			},
+			Spec: subv1.SubscriptionSpec{
+				Channel: chnKey.String(),
+				Placement: &plrv1alpha1.Placement{
+					GenericPlacementFields: plrv1alpha1.GenericPlacementFields{
+						Clusters: []plrv1alpha1.GenericClusterReference{
+							{Name: "test-cluster"},
+						},
+					},
+				},
+			},
+		}
+	)
+
+	It("register/de-register a subscription", func() {
+		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
+		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
+
+		testBranch := "master"
+		defer func() {
+			Expect(k8sClt.Delete(ctx, chnIns.DeepCopy())).Should(Succeed())
+			Expect(k8sClt.Delete(ctx, subIns.DeepCopy())).Should(Succeed())
+		}()
+
+		Eventually(registerSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+
+		sr := gitOps.GetSubRecords()
+
+		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+
+		rr := gitOps.GetRepoRecords()
+
+		branchInfo := rr[ansibleGitURL].branchs[testBranch]
+		fmt.Printf("izhang ---------- rr = %+v\n%#v\n", rr, branchInfo)
+
+		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+
+		Eventually(checkGitRegCommit(testBranch), pullInterval*3, pullInterval).Should(Succeed())
+
+		Eventually(deRegisterSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		sr = gitOps.GetSubRecords()
+
+		Expect(sr).ShouldNot(HaveKey(dSubKey))
+
+		rr = gitOps.GetRepoRecords()
+
+		Expect(rr).ShouldNot(HaveKey(ansibleGitURL))
+		Expect(rr).Should(HaveLen(0))
+	})
+
+	It("register/deRegisterSub the 2nd subscription", func() {
+		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
+		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
+
+		sub2 := subIns.DeepCopy()
+		sub2Key := types.NamespacedName{Namespace: testNs, Name: "2ndsub"}
+
+		sub2.SetName(sub2Key.Name)
+		sub2.SetNamespace(sub2Key.Namespace)
+		Expect(k8sClt.Create(ctx, sub2.DeepCopy())).Should(Succeed())
+
+		testBranch := "master"
+		defer func() {
+			Expect(k8sClt.Delete(ctx, chnIns.DeepCopy())).Should(Succeed())
+			Expect(k8sClt.Delete(ctx, subIns.DeepCopy())).Should(Succeed())
+			Expect(k8sClt.Delete(ctx, sub2.DeepCopy())).Should(Succeed())
+		}()
+
+		Eventually(registerSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(registerSub(sub2Key), pullInterval*3, pullInterval).Should(Succeed())
+
+		sr := gitOps.GetSubRecords()
+
+		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+		Expect(sr[sub2Key]).Should(Equal(ansibleGitURL))
+
+		rr := gitOps.GetRepoRecords()
+
+		branchInfo := rr[ansibleGitURL].branchs[testBranch]
+
+		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).Should(HaveKey(sub2Key))
+
+		Eventually(deRegisterSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+
+		sr = gitOps.GetSubRecords()
+
+		Expect(sr).ShouldNot(HaveKey(dSubKey))
+		Expect(sr[sub2Key]).Should(Equal(ansibleGitURL))
+
+		rr = gitOps.GetRepoRecords()
+
+		branchInfo = rr[ansibleGitURL].branchs[testBranch]
+		Expect(branchInfo.registeredSub).ShouldNot(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).Should(HaveKey(sub2Key))
+		Expect(branchInfo.registeredSub).Should(HaveLen(1))
+
+		Eventually(checkGitRegCommit(testBranch), pullInterval*3, pullInterval).Should(Succeed())
+	})
+
+	It("should update commitID", func() {
+		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
+		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
+
+		testBranch := "master"
+		defer func() {
+			Expect(k8sClt.Delete(ctx, chnIns.DeepCopy())).Should(Succeed())
+			Expect(k8sClt.Delete(ctx, subIns.DeepCopy())).Should(Succeed())
+		}()
+
+		Eventually(registerSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+
+		sr := gitOps.GetSubRecords()
+
+		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+
+		rr := gitOps.GetRepoRecords()
+
+		branchInfo := rr[ansibleGitURL].branchs[testBranch]
+		//Expect(branchInfo.lastCommitID).Should(Equal(defaultCommit))
+		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+
+		detectTargetCommit := func(key types.NamespacedName) func() error {
+			return func() error {
+				u := &subv1.Subscription{}
+
+				if err := k8sClt.Get(ctx, key, u); err != nil {
+					return err
+				}
+
+				sCommit := u.GetAnnotations()[subv1.AnnotationGitCommit]
+				ssCommit := u.GetAnnotations()[subv1.AnnotationGithubCommit]
+
+				rr := gitOps.GetRepoRecords()
+
+				branchInfo := rr[ansibleGitURL].branchs[testBranch]
+				if !strings.EqualFold(branchInfo.lastCommitID, defaultCommit) {
+					return fmt.Errorf("subscription commit is not updated in git registry")
+				}
+
+				if strings.EqualFold(sCommit, defaultCommit) || strings.EqualFold(ssCommit, defaultCommit) {
+					return nil
+				}
+				return fmt.Errorf("subscription commit is not updated")
+			}
+		}
+
+		Eventually(detectTargetCommit(dSubKey), pullInterval*10, pullInterval).Should(Succeed())
+	})
+})

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -843,6 +843,9 @@ func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscr
 	if !utils.IsEqualSubScriptionStatus(&sub.Status, &newsubstatus) {
 		klog.V(1).Infof("check subscription status sub: %v/%v, substatus: %#v, newsubstatus: %#v",
 			sub.Namespace, sub.Name, sub.Status, newsubstatus)
+
+		//perserve the Ansiblejob status
+		newsubstatus.AnsibleJobsStatus = *sub.Status.AnsibleJobsStatus.DeepCopy()
 		newsubstatus.DeepCopyInto(&sub.Status)
 	}
 

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -424,7 +424,6 @@ func subAdminClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 
 func (r *ReconcileSubscription) setHubSubscriptionStatus(sub *appv1.Subscription) {
 	// Get propagation status from the subscription deployable
-
 	hubdpl := &dplv1.Deployable{}
 	err := r.Get(context.TODO(), types.NamespacedName{Name: sub.Name + "-deployable", Namespace: sub.Namespace}, hubdpl)
 
@@ -711,7 +710,6 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 			if res.RequeueAfter == time.Duration(0) {
 				res.RequeueAfter = defaulRequeueInterval
 				r.logger.Error(err, fmt.Sprintf("%s failed to update spec or metadata, will retry after %s", PrintHelper(nIns), res.RequeueAfter))
-
 			}
 
 			return

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -82,6 +82,8 @@ const (
 	placementRuleFlag          = "--fired-by-placementrule"
 )
 
+var defaulRequeueInterval = time.Second * 3
+
 // Add creates a new Subscription Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -91,14 +93,18 @@ func Add(mgr manager.Manager) error {
 //Option provide easy way to test the reconciler
 type Option func(*ReconcileSubscription)
 
+func resetHubGitOps(g GitOps) Option {
+	return func(r *ReconcileSubscription) {
+		r.hubGitOps = g
+	}
+}
+
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, op ...Option) reconcile.Reconciler {
 	erecorder, _ := utils.NewEventRecorder(mgr.GetConfig(), mgr.GetScheme())
 	logger := klogr.New().WithName(hubLogger)
 
-	gitWatcher := NewHookGit(mgr.GetClient(), logger)
-
-	hk := NewAnsibleHooks(mgr.GetClient(), defaultHookRequeueInterval, setLogger(logger), setGitOps(gitWatcher))
+	gitOps := NewHookGit(mgr.GetClient(), setHubGitOpsLogger(logger))
 
 	rec := &ReconcileSubscription{
 		Client: mgr.GetClient(),
@@ -108,15 +114,18 @@ func newReconciler(mgr manager.Manager, op ...Option) reconcile.Reconciler {
 		eventRecorder:       erecorder,
 		logger:              logger,
 		hookRequeueInterval: defaultHookRequeueInterval,
-		hooks:               hk,
+		hooks:               NewAnsibleHooks(mgr.GetClient(), defaultHookRequeueInterval, setLogger(logger), setGitOps(gitOps)),
+		hubGitOps:           gitOps,
 	}
 
 	for _, f := range op {
 		f(rec)
 	}
 
+	rec.hooks.ResetGitOps(rec.hubGitOps)
+
 	//this is used to start up the git watcher
-	if err := mgr.Add(gitWatcher); err != nil {
+	if err := mgr.Add(rec.hubGitOps); err != nil {
 		logger.Error(err, "failed to start git watcher")
 	}
 
@@ -342,6 +351,7 @@ type ReconcileSubscription struct {
 	eventRecorder       *utils.EventRecorder
 	hookRequeueInterval time.Duration
 	hooks               HookProcessor
+	hubGitOps           GitOps
 }
 
 // CreateSubscriptionAdminRBAC checks existence of subscription-admin clusterrole and clusterrolebinding
@@ -484,6 +494,8 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result rec
 				return reconcile.Result{}, err
 			}
 
+			r.hubGitOps.DeregisterBranch(request.NamespacedName)
+
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -503,6 +515,7 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result rec
 		instance.Status.Phase = appv1.SubscriptionPropagationFailed
 		instance.Status.Reason = "Placement must be specified"
 	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) {
+		r.hubGitOps.RegisterBranch(instance)
 		// register will skip the failed clone repo
 		if err := r.hooks.RegisterSubscription(request.NamespacedName, forceRegister, placementRuleRv); err != nil {
 			logger.Error(err, "failed to register hooks, skip the subscription reconcile")
@@ -695,7 +708,7 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 	if utils.IsSubscriptionBasicChanged(oIns, nIns) { //if subresource enabled, the update client won't update the status
 		if err := r.Client.Update(context.TODO(), nIns.DeepCopy()); err != nil {
 			if res.RequeueAfter == time.Duration(0) {
-				res.RequeueAfter = 1 * time.Second
+				res.RequeueAfter = defaulRequeueInterval
 				r.logger.Error(err, fmt.Sprintf("failed to update status, will retry after %s", res.RequeueAfter))
 			}
 
@@ -705,8 +718,8 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 		// due to the predict func, it's necessary to re-queue, since the status
 		// change isn't committed yet
 		if res.RequeueAfter == time.Duration(0) {
-			res.RequeueAfter = 5 * time.Second
-			r.logger.Info(fmt.Sprintf("%s on prehook topo annotation flow, will retry after %s", PrintHelper(nIns), res.RequeueAfter))
+			res.RequeueAfter = defaulRequeueInterval
+			r.logger.Info(fmt.Sprintf("%s on spec or annotation update success flow, will retry after %s", PrintHelper(nIns), res.RequeueAfter))
 		}
 
 		return
@@ -726,7 +739,7 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 
 		if err := r.Client.Status().Update(context.TODO(), nIns.DeepCopy()); err != nil {
 			if res.RequeueAfter == time.Duration(0) {
-				res.RequeueAfter = 1 * time.Second
+				res.RequeueAfter = defaulRequeueInterval
 				r.logger.Error(err, fmt.Sprintf("failed to update status, will retry after %s", res.RequeueAfter))
 			}
 
@@ -734,7 +747,7 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 		}
 
 		if res.RequeueAfter == time.Duration(0) {
-			res.RequeueAfter = 1 * time.Second
+			res.RequeueAfter = defaulRequeueInterval
 			r.logger.Info(fmt.Sprintf("only update status, will retry %s for possible posthook", res.RequeueAfter))
 		}
 
@@ -776,7 +789,7 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 		}
 
 		if res.RequeueAfter == time.Duration(0) {
-			res.RequeueAfter = 1 * time.Second
+			res.RequeueAfter = defaulRequeueInterval
 			r.logger.Error(err, fmt.Sprintf("failed to update status, will retry after %s", res.RequeueAfter))
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Addressing issue:

https://github.com/open-cluster-management/backlog/issues/5938
https://github.com/open-cluster-management/backlog/issues/5838

Both the above issues are caused by the out-dated commit annotation, the fix will sperate the git commit update to its own logic as `git watcher`. 

The separated logic `git watcher` is running in a `goroutine` which has the same lifecycle as the operator. During the lifecycle, the operator will register/deregister itself to the `git watcher`. Once it's registered, then the `git watcher` will responsible to update the subscription commitID annotation when the target branch is updated.

In this way, for issue 5938, we are mapping the branch to multiple subscriptions, it should decrease the outgoing requests to Github.  For issue 5838, the subscription will tightly link to git commit, since the latest commitID will get updated to the subscription by the `git watcher` as long as the `git watch` detects a new commitID.

Also, the `git watcher` provides some helper functions, for mocking test cases, or gets the latest commitID of a given subscription instance when needed.

**Note: the `git watcher` is running the update check every 90seconds by default**
