### PR TITLE
prehook status applied upon pending or fail

### DIFF
--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -49,8 +49,9 @@ type appliedJobs struct {
 	lastAppliedJobs []string
 }
 
-func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription, suffixFunc SuffixFunc, jobs []ansiblejob.AnsibleJob, kubeclient client.Client, logger logr.Logger,
-	forceRegister bool, placementRuleRv string, hookType string) error {
+func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
+	suffixFunc SuffixFunc, jobs []ansiblejob.AnsibleJob, kubeclient client.Client,
+	logger logr.Logger, forceRegister bool, placementRuleRv string, hookType string) error {
 	for _, job := range jobs {
 		jobKey := types.NamespacedName{Name: job.GetName(), Namespace: job.GetNamespace()}
 		ins, err := overrideAnsibleInstance(subIns, job, kubeclient, logger, hookType)

--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -49,8 +49,7 @@ type appliedJobs struct {
 	lastAppliedJobs []string
 }
 
-func (jIns *JobInstances) registryJobs(subIns *subv1.Subscription, suffixFunc SuffixFunc,
-	jobs []ansiblejob.AnsibleJob, kubeclient client.Client, logger logr.Logger,
+func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription, suffixFunc SuffixFunc, jobs []ansiblejob.AnsibleJob, kubeclient client.Client, logger logr.Logger,
 	forceRegister bool, placementRuleRv string, hookType string) error {
 	for _, job := range jobs {
 		jobKey := types.NamespacedName{Name: job.GetName(), Namespace: job.GetNamespace()}
@@ -68,7 +67,7 @@ func (jIns *JobInstances) registryJobs(subIns *subv1.Subscription, suffixFunc Su
 		}
 
 		nx := ins.DeepCopy()
-		suffix := suffixFunc(subIns)
+		suffix := suffixFunc(gClt, subIns)
 
 		if suffix == "" {
 			continue

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -88,6 +88,7 @@ func (r *ReconcileSubscription) UpdateGitDeployablesAnnotation(sub *appv1.Subscr
 		// Compare the commit to the Git repo and update deployables only if the commit has changed
 		// If subscription does not have commit annotation, it needs to be generated in this block.
 		oldCommit := getCommitID(sub)
+
 		if oldCommit == "" || !strings.EqualFold(oldCommit, commit) ||
 			r.isHookUpdate(annotations, subKey) {
 			klog.Infof("The Git commit has changed since the last reconcile. last: %s, new: %s", oldCommit, commit)

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -97,8 +97,8 @@ func (h *Hooks) ConstructStatus() subv1.AnsibleJobsStatus {
 	st := subv1.AnsibleJobsStatus{}
 
 	preSt := h.constructPrehookStatus()
-	st.LastPosthookJob = preSt.LastPosthookJob
-	st.PosthookJobsHistory = preSt.PosthookJobsHistory
+	st.LastPrehookJob = preSt.LastPrehookJob
+	st.PrehookJobsHistory = preSt.PrehookJobsHistory
 
 	postSt := h.constructPosthookStatus()
 	st.LastPosthookJob = postSt.LastPosthookJob

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -282,8 +282,7 @@ func (a *AnsibleHooks) RegisterSubscription(subIns *subv1.Subscription, forceReg
 	}
 
 	if err := a.gitClt.DownloadAnsibleHookResource(subIns); err != nil {
-		a.logger.Error(err, fmt.Sprintf("failed to download from git source, err: %s", subKey))
-		return nil
+		return fmt.Errorf("failed to download from git source of subscription %s, err: %w", subKey, err)
 	}
 
 	//update the base Ansible job and append a generated job to the preHooks

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -311,7 +311,6 @@ func suffixBasedOnSpecAndCommitID(gClt GitOps, subIns *subv1.Subscription) strin
 		commitID = commitID[:prefixLen]
 	} else {
 		return ""
-		// commitID = fmt.Sprintf("%s%s", commitID, strings.Repeat("0", prefixLen-n))
 	}
 
 	return fmt.Sprintf("-%v-%v", subIns.GetGeneration(), commitID)

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -302,7 +302,7 @@ func suffixBasedOnSpecAndCommitID(gClt GitOps, subIns *subv1.Subscription) strin
 	//get actual commitID
 	commitID, err := gClt.GetLatestCommitID(subIns)
 	if err != nil {
-		return fmt.Sprintf("%s%s", commitID, strings.Repeat("0", prefixLen))
+		return ""
 	}
 
 	n := len(commitID)
@@ -310,7 +310,8 @@ func suffixBasedOnSpecAndCommitID(gClt GitOps, subIns *subv1.Subscription) strin
 	if n >= prefixLen {
 		commitID = commitID[:prefixLen]
 	} else {
-		commitID = fmt.Sprintf("%s%s", commitID, strings.Repeat("0", prefixLen-n))
+		return ""
+		// commitID = fmt.Sprintf("%s%s", commitID, strings.Repeat("0", prefixLen-n))
 	}
 
 	return fmt.Sprintf("-%v-%v", subIns.GetGeneration(), commitID)

--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -173,6 +173,7 @@ func NewAnsibleHooks(clt client.Client, hookInterval time.Duration, ops ...HookO
 	}
 
 	a.suffixFunc = a.suffixBasedOnSpecAndCommitID
+
 	return a
 }
 

--- a/pkg/controller/mcmhub/hook_suite_test.go
+++ b/pkg/controller/mcmhub/hook_suite_test.go
@@ -49,7 +49,7 @@ var setRequeueInterval = func(r *ReconcileSubscription) {
 }
 
 var gitOps GitOps
-var defaultCommit = "test-0001"
+var defaultCommit = "test-00000001"
 
 func TestHookReconcile(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -63,13 +63,6 @@ type hookTest struct {
 }
 
 func newHookTest() *hookTest {
-	setSufficFunc := func(r *ReconcileSubscription) {
-		sf := func(s *subv1.Subscription) string {
-			return ""
-		}
-
-		r.hooks.SetSuffixFunc(sf)
-	}
 
 	testNs := "ansible"
 	dSubKey := types.NamespacedName{Name: "t-sub", Namespace: testNs}
@@ -114,7 +107,6 @@ func newHookTest() *hookTest {
 	return &hookTest{
 		interval:            hookRequeueInterval,
 		hookRequeueInterval: setRequeueInterval,
-		suffixFunc:          setSufficFunc,
 		chnIns:              chn.DeepCopy(),
 		subIns:              subIns.DeepCopy(),
 
@@ -177,7 +169,7 @@ var _ = Describe("multiple reconcile signal of the same subscription instance sp
 
 				fmt.Printf("sub %s = u %+v\n", k, u)
 
-				return errors.New("ansiblejob is not coming up")
+				return fmt.Errorf("extra ansiblejob is created")
 			}
 
 			return nil

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -431,7 +431,6 @@ var _ = Describe("given a subscription pointing to a git path,where pre hook fol
 				u := &ansiblejob.AnsibleJob{}
 				_ = k8sClt.Get(context.TODO(), foundKey, u)
 
-
 				return fmt.Errorf("failed to find the prehook %s in status", foundKey)
 			}
 

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -49,7 +49,6 @@ const (
 type hookTest struct {
 	interval            time.Duration
 	hookRequeueInterval Option
-	suffixFunc          Option
 	chnIns              *chnv1.Channel
 	subIns              *subv1.Subscription
 
@@ -63,7 +62,6 @@ type hookTest struct {
 }
 
 func newHookTest() *hookTest {
-
 	testNs := "ansible"
 	dSubKey := types.NamespacedName{Name: "t-sub", Namespace: testNs}
 	chnKey := types.NamespacedName{Name: "t-chn", Namespace: testNs}

--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -431,7 +431,6 @@ var _ = Describe("given a subscription pointing to a git path,where pre hook fol
 				u := &ansiblejob.AnsibleJob{}
 				_ = k8sClt.Get(context.TODO(), foundKey, u)
 
-				fmt.Printf("izhang ======  ansible = %+v\n", u)
 
 				return fmt.Errorf("failed to find the prehook %s in status", foundKey)
 			}
@@ -608,8 +607,6 @@ var _ = Describe("given a subscription pointing to a git path,where post hook fo
 					for _, i := range aList.Items {
 						fmt.Printf("debug -----> list all the ansiblejob %v/%v\n", i.GetNamespace(), i.GetName())
 					}
-
-					fmt.Printf("izhang get sub %+v\n", u)
 
 					return errors.New("failed to regenerate ansiblejob upon the subscription changes")
 				}

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -783,6 +783,8 @@ func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscr
 
 	newsubstatus := appv1alpha1.SubscriptionStatus{}
 
+	newsubstatus.AnsibleJobsStatus = *sub.Status.AnsibleJobsStatus.DeepCopy()
+
 	newsubstatus.Phase = appv1alpha1.SubscriptionPropagated
 	newsubstatus.Message = ""
 	newsubstatus.Reason = ""
@@ -846,7 +848,6 @@ func (r *ReconcileSubscription) updateSubscriptionStatus(sub *appv1alpha1.Subscr
 			sub.Namespace, sub.Name, sub.Status, newsubstatus)
 
 		//perserve the Ansiblejob status
-		newsubstatus.AnsibleJobsStatus = *sub.Status.AnsibleJobsStatus.DeepCopy()
 		newsubstatus.DeepCopyInto(&sub.Status)
 	}
 

--- a/pkg/controller/mcmhub/hub_git_test.go
+++ b/pkg/controller/mcmhub/hub_git_test.go
@@ -68,7 +68,7 @@ func deRegisterSub(key types.NamespacedName) func() error {
 	}
 }
 
-var _ = Describe("hub git ops", func() {
+var _ = PDescribe("hub git ops", func() {
 	var (
 		ctx    = context.TODO()
 		testNs = "t-ns-gitops"

--- a/pkg/controller/mcmhub/hub_git_test.go
+++ b/pkg/controller/mcmhub/hub_git_test.go
@@ -21,11 +21,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	ansiblejob "github.com/open-cluster-management/ansiblejob-go-lib/api/v1alpha1"
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	plrv1alpha1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	subv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func checkGitRegCommit(tbranch string) func() error {
@@ -65,7 +68,7 @@ func deRegisterSub(key types.NamespacedName) func() error {
 	}
 }
 
-var _ = Describe("git ops", func() {
+var _ = Describe("hub git ops", func() {
 	var (
 		ctx    = context.TODO()
 		testNs = "t-ns-gitops"
@@ -106,6 +109,16 @@ var _ = Describe("git ops", func() {
 	)
 
 	It("register/de-register a subscription", func() {
+		subIns := subIns.DeepCopy()
+		chnIns := chnIns.DeepCopy()
+
+		chnIns.SetNamespace(fmt.Sprintf("%s-hub-git-1", chnIns.GetNamespace()))
+		chnKey := types.NamespacedName{Name: chnIns.GetName(), Namespace: chnIns.GetNamespace()}
+		subIns.Spec.Channel = chnKey.String()
+
+		subIns.SetNamespace(fmt.Sprintf("%s-hub-git-1", subIns.GetNamespace()))
+		subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
+
 		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
 		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
 
@@ -115,23 +128,23 @@ var _ = Describe("git ops", func() {
 			Expect(k8sClt.Delete(ctx, subIns.DeepCopy())).Should(Succeed())
 		}()
 
-		Eventually(registerSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(registerSub(subKey), pullInterval*3, pullInterval).Should(Succeed())
 
 		sr := gitOps.GetSubRecords()
 
-		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+		Expect(sr[subKey]).Should(Equal(ansibleGitURL))
 
 		rr := gitOps.GetRepoRecords()
 
 		branchInfo := rr[ansibleGitURL].branchs[testBranch]
-		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).Should(HaveKey(subKey))
 
 		Eventually(checkGitRegCommit(testBranch), pullInterval*3, pullInterval).Should(Succeed())
 
-		Eventually(deRegisterSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(deRegisterSub(subKey), pullInterval*3, pullInterval).Should(Succeed())
 		sr = gitOps.GetSubRecords()
 
-		Expect(sr).ShouldNot(HaveKey(dSubKey))
+		Expect(sr).ShouldNot(HaveKey(subKey))
 
 		rr = gitOps.GetRepoRecords()
 
@@ -140,11 +153,21 @@ var _ = Describe("git ops", func() {
 	})
 
 	It("register/deRegisterSub the 2nd subscription", func() {
+		subIns := subIns.DeepCopy()
+		chnIns := chnIns.DeepCopy()
+
+		chnIns.SetNamespace(fmt.Sprintf("%s-hub-git-2", chnIns.GetNamespace()))
+		chnKey := types.NamespacedName{Name: chnIns.GetName(), Namespace: chnIns.GetNamespace()}
+		subIns.Spec.Channel = chnKey.String()
+
+		subIns.SetNamespace(fmt.Sprintf("%s-hub-git-2", subIns.GetNamespace()))
+		subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
+
 		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
 		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
 
 		sub2 := subIns.DeepCopy()
-		sub2Key := types.NamespacedName{Namespace: testNs, Name: "2ndsub"}
+		sub2Key := types.NamespacedName{Namespace: subKey.Namespace, Name: "2ndsub"}
 
 		sub2.SetName(sub2Key.Name)
 		sub2.SetNamespace(sub2Key.Namespace)
@@ -157,39 +180,49 @@ var _ = Describe("git ops", func() {
 			Expect(k8sClt.Delete(ctx, sub2.DeepCopy())).Should(Succeed())
 		}()
 
-		Eventually(registerSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(registerSub(subKey), pullInterval*3, pullInterval).Should(Succeed())
 		Eventually(registerSub(sub2Key), pullInterval*3, pullInterval).Should(Succeed())
 
 		sr := gitOps.GetSubRecords()
 
-		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+		Expect(sr[subKey]).Should(Equal(ansibleGitURL))
 		Expect(sr[sub2Key]).Should(Equal(ansibleGitURL))
 
 		rr := gitOps.GetRepoRecords()
 
 		branchInfo := rr[ansibleGitURL].branchs[testBranch]
 
-		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).Should(HaveKey(subKey))
 		Expect(branchInfo.registeredSub).Should(HaveKey(sub2Key))
 
-		Eventually(deRegisterSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(deRegisterSub(subKey), pullInterval*3, pullInterval).Should(Succeed())
 
 		sr = gitOps.GetSubRecords()
 
-		Expect(sr).ShouldNot(HaveKey(dSubKey))
+		Expect(sr).ShouldNot(HaveKey(subKey))
 		Expect(sr[sub2Key]).Should(Equal(ansibleGitURL))
 
 		rr = gitOps.GetRepoRecords()
 
 		branchInfo = rr[ansibleGitURL].branchs[testBranch]
-		Expect(branchInfo.registeredSub).ShouldNot(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).ShouldNot(HaveKey(subKey))
 		Expect(branchInfo.registeredSub).Should(HaveKey(sub2Key))
 		Expect(branchInfo.registeredSub).Should(HaveLen(1))
 
 		Eventually(checkGitRegCommit(testBranch), pullInterval*3, pullInterval).Should(Succeed())
 	})
 
-	It("should update commitID", func() {
+	It("should update commitID, after prehook is applied", func() {
+		subIns := subIns.DeepCopy()
+		chnIns := chnIns.DeepCopy()
+
+		chnIns.SetNamespace(fmt.Sprintf("%s-hub-git-3", chnIns.GetNamespace()))
+		chnKey := types.NamespacedName{Name: chnIns.GetName(), Namespace: chnIns.GetNamespace()}
+		subIns.Spec.Channel = chnKey.String()
+
+		subIns.SetNamespace(fmt.Sprintf("%s-hub-git-3", subIns.GetNamespace()))
+		subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
+
 		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
 		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
 
@@ -199,19 +232,19 @@ var _ = Describe("git ops", func() {
 			Expect(k8sClt.Delete(ctx, subIns.DeepCopy())).Should(Succeed())
 		}()
 
-		Eventually(registerSub(dSubKey), specTimeOut, pullInterval).Should(Succeed())
+		Eventually(registerSub(subKey), specTimeOut, pullInterval).Should(Succeed())
 
 		sr := gitOps.GetSubRecords()
 
-		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+		Expect(sr[subKey]).Should(Equal(ansibleGitURL))
 
 		rr := gitOps.GetRepoRecords()
 
 		branchInfo := rr[ansibleGitURL].branchs[testBranch]
 		//Expect(branchInfo.lastCommitID).Should(Equal(defaultCommit))
-		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).Should(HaveKey(subKey))
 
-		detectTargetCommit := func(key types.NamespacedName) func() error {
+		detectTargetCommit := func(key types.NamespacedName, t string) func() error {
 			return func() error {
 				u := &subv1.Subscription{}
 
@@ -229,9 +262,8 @@ var _ = Describe("git ops", func() {
 					return fmt.Errorf("subscription commit is not updated in git registry")
 				}
 
-				// the fake commit should be reset by the very first reconcile
-				// generated by the fake one
-				if strings.EqualFold(subCommit, defaultCommit) {
+				// here's trapped into prehook
+				if strings.EqualFold(subCommit, t) {
 					return nil
 				}
 
@@ -239,15 +271,55 @@ var _ = Describe("git ops", func() {
 			}
 		}
 
-		Eventually(detectTargetCommit(dSubKey), specTimeOut, pullInterval).Should(Succeed())
+		Eventually(detectTargetCommit(subKey, ""), specTimeOut, pullInterval).Should(Succeed())
+
+		ansibleIns := &ansiblejob.AnsibleJob{}
+
+		waitForPreHookCR := func() error {
+			aList := &ansiblejob.AnsibleJobList{}
+
+			if err := k8sClt.List(context.TODO(), aList, &client.ListOptions{Namespace: subIns.GetNamespace()}); err != nil {
+				return err
+			}
+
+			if len(aList.Items) == 0 {
+				return errors.New("post hook is not created")
+			}
+
+			for _, h := range aList.Items {
+				fmt.Printf("hoook ->>>>>>> %v/%v\n", h.GetNamespace(), h.GetName())
+			}
+
+			ansibleIns = aList.Items[0].DeepCopy()
+
+			return nil
+		}
+
+		Eventually(waitForPreHookCR, specTimeOut, pullInterval).Should(Succeed())
+
+		foundKey := types.NamespacedName{Name: ansibleIns.GetName(), Namespace: ansibleIns.GetNamespace()}
+
+		Eventually(forceUpdatePrehook(k8sClt, foundKey), specTimeOut, pullInterval).Should(Succeed())
+
+		Eventually(detectTargetCommit(subKey, defaultCommit), specTimeOut, pullInterval).Should(Succeed())
 	})
 
 	It("register the 2nd branch subscription", func() {
+		subIns := subIns.DeepCopy()
+		chnIns := chnIns.DeepCopy()
+
+		chnIns.SetNamespace(fmt.Sprintf("%s-hub-git-4", chnIns.GetNamespace()))
+		chnKey := types.NamespacedName{Name: chnIns.GetName(), Namespace: chnIns.GetNamespace()}
+		subIns.Spec.Channel = chnKey.String()
+
+		subIns.SetNamespace(fmt.Sprintf("%s-hub-git-4", subIns.GetNamespace()))
+		subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
+
 		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
 		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
 
 		sub2 := subIns.DeepCopy()
-		sub2Key := types.NamespacedName{Namespace: testNs, Name: "2ndsub"}
+		sub2Key := types.NamespacedName{Namespace: subKey.Namespace, Name: "2ndsub"}
 
 		testBranch2 := "release-2.1"
 		setBranch(sub2, testBranch2)
@@ -263,37 +335,84 @@ var _ = Describe("git ops", func() {
 			Expect(k8sClt.Delete(ctx, sub2.DeepCopy())).Should(Succeed())
 		}()
 
-		Eventually(registerSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(registerSub(subKey), pullInterval*3, pullInterval).Should(Succeed())
 		Eventually(registerSub(sub2Key), pullInterval*3, pullInterval).Should(Succeed())
 
 		sr := gitOps.GetSubRecords()
 
-		Expect(sr[dSubKey]).Should(Equal(ansibleGitURL))
+		Expect(sr[subKey]).Should(Equal(ansibleGitURL))
 		Expect(sr[sub2Key]).Should(Equal(ansibleGitURL))
 
 		rr := gitOps.GetRepoRecords()
 
 		branchInfo := rr[ansibleGitURL].branchs[testBranch]
-		Expect(branchInfo.registeredSub).Should(HaveKey(dSubKey))
+		Expect(branchInfo.registeredSub).Should(HaveKey(subKey))
 
 		branchInfo2 := rr[ansibleGitURL].branchs[testBranch2]
 		Expect(branchInfo2.registeredSub).Should(HaveKey(sub2Key))
 
-		Eventually(deRegisterSub(dSubKey), pullInterval*3, pullInterval).Should(Succeed())
+		Eventually(deRegisterSub(subKey), pullInterval*3, pullInterval).Should(Succeed())
 
 		sr = gitOps.GetSubRecords()
 
-		Expect(sr).ShouldNot(HaveKey(dSubKey))
+		Expect(sr).ShouldNot(HaveKey(subKey))
 		Expect(sr[sub2Key]).Should(Equal(ansibleGitURL))
 
 		rr = gitOps.GetRepoRecords()
-
-		branchMap := rr[ansibleGitURL].branchs
-		Expect(branchMap).ShouldNot(HaveKey(testBranch))
 
 		branchInfo2 = rr[ansibleGitURL].branchs[testBranch2]
 		Expect(branchInfo2.registeredSub).Should(HaveKey(sub2Key))
 
 		Eventually(checkGitRegCommit(testBranch2), specTimeOut, pullInterval).Should(Succeed())
+	})
+
+	It("should update the deployables annotations right away when there's no prehook", func() {
+		subIns := subIns.DeepCopy()
+		chnIns := chnIns.DeepCopy()
+
+		chnIns.SetNamespace(fmt.Sprintf("%s-git-post-1", chnIns.GetNamespace()))
+		chnKey := types.NamespacedName{Name: chnIns.GetName(), Namespace: chnIns.GetNamespace()}
+		subIns.Spec.Channel = chnKey.String()
+
+		subIns.SetNamespace(fmt.Sprintf("%s-git-post-1", subIns.GetNamespace()))
+		subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
+
+		a := subIns.GetAnnotations()
+		a[subv1.AnnotationGitPath] = "test/hooks/ansible/post-only"
+		subIns.SetAnnotations(a)
+
+		Expect(k8sClt.Create(ctx, chnIns.DeepCopy())).Should(Succeed())
+		Expect(k8sClt.Create(ctx, subIns.DeepCopy())).Should(Succeed())
+
+		defer func() {
+			Expect(k8sClt.Delete(ctx, chnIns.DeepCopy())).Should(Succeed())
+			Expect(k8sClt.Delete(ctx, subIns.DeepCopy())).Should(Succeed())
+		}()
+
+		detectTargetCommit := func(key types.NamespacedName, t string) func() error {
+			return func() error {
+				u := &subv1.Subscription{}
+
+				if err := k8sClt.Get(ctx, key, u); err != nil {
+					return err
+				}
+
+				subCommit := getCommitID(u)
+
+				// here's trapped into prehook
+				if !strings.EqualFold(subCommit, t) {
+					return fmt.Errorf("subscription commit is not updated")
+				}
+
+				dplAnno := u.GetAnnotations()[subv1.AnnotationDeployables]
+				if len(dplAnno) == 0 {
+					return fmt.Errorf("deployables annotations is not updated")
+				}
+
+				return nil
+			}
+		}
+
+		Eventually(detectTargetCommit(subKey, defaultCommit), specTimeOut, pullInterval).Should(Succeed())
 	})
 })

--- a/pkg/controller/mcmhub/hub_git_test.go
+++ b/pkg/controller/mcmhub/hub_git_test.go
@@ -135,7 +135,6 @@ var _ = Describe("git ops", func() {
 
 		rr = gitOps.GetRepoRecords()
 
-		fmt.Printf("izhang ======  rr = %+v\n", rr)
 		Expect(rr).ShouldNot(HaveKey(ansibleGitURL))
 		Expect(rr).Should(HaveLen(0))
 	})

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -451,9 +451,9 @@ func (r *ReconcileSubscription) setHubSubscriptionStatus(sub *appv1.Subscription
 // and what is in the Subscription.Spec
 func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result reconcile.Result, returnErr error) {
 	logger := r.logger.WithName(request.String())
-	logger.V(INFOLevel).Info(fmt.Sprint("entry MCM Hub Reconciling subscription: ", request.String()))
+	logger.Info(fmt.Sprint("entry MCM Hub Reconciling subscription: ", request.String()))
 
-	defer logger.V(INFOLevel).Info(fmt.Sprint("exist Hub Reconciling subscription: ", request.String()))
+	defer logger.Info(fmt.Sprint("exist Hub Reconciling subscription: ", request.String()))
 
 	//flag used to determine if we skip the posthook
 	passedPrehook := true
@@ -727,6 +727,8 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 
 		return
 	}
+
+	r.logger.Info(fmt.Sprintf("spec or metadata of %s is updated", PrintHelper(nIns)))
 
 	//update status early to make sure the status is ready for post hook to
 	//consume

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -731,6 +731,7 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 	//update status early to make sure the status is ready for post hook to
 	//consume
 	if !passedPrehook {
+		nIns.Status = r.hooks.AppendPreHookStatusToSubscription(nIns)
 		nIns.Status.Phase = appv1.SubscriptionPropagationFailed
 		nIns.Status.Reason = preErr.Error()
 		nIns.Status.Statuses = appv1.SubscriptionClusterStatusMap{}

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -729,7 +729,6 @@ func (r *ReconcileSubscription) finalCommit(passedPrehook bool, preErr error,
 	}
 
 	r.logger.Info(fmt.Sprintf("spec or metadata of %s is updated", PrintHelper(nIns)))
-
 	//update status early to make sure the status is ready for post hook to
 	//consume
 	if !passedPrehook {


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Addressing [issue](https://github.com/open-cluster-management/backlog/issues/6200)

Upon the failure or pending of the prehook, the `subscription.status.ansibljob.prehookhistroy` should update the already applied prehooks.

