### PR TITLE
skip creating ansiblejob that are coming from a forceregister when there are no other ansiblejob on the record

### DIFF
--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -79,6 +79,13 @@ func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 		jobRecords.Original = ins
 
 		if forceRegister {
+			if len(jobRecords.Instance) == 0 {
+				logger.Info("forceRegister is enabled but there are no other jobs on the record, skip creating AnsibleJob.")
+				jobRecords.mux.Unlock()
+
+				return nil
+			}
+
 			plrSuffixFunc := func() string {
 				return fmt.Sprintf("-%v-%v", subIns.GetGeneration(), placementRuleRv)
 			}


### PR DESCRIPTION
placementRule change reconcile shouldn't be the first AnsibleJob that gets created. The first job should come from the actual subscription reconcile.

Signed-off-by: Mike Ng <ming@redhat.com>