### PR TITLE
Fix deep equal of annotation

### DIFF
--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -78,14 +78,7 @@ func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 		jobRecords.mux.Lock()
 		jobRecords.Original = ins
 
-		if forceRegister {
-			if len(jobRecords.Instance) == 0 {
-				logger.Info("forceRegister is enabled but there are no other jobs on the record, skip creating AnsibleJob.")
-				jobRecords.mux.Unlock()
-
-				return nil
-			}
-
+		if forceRegister && len(jobRecords.Instance) != 0 {
 			plrSuffixFunc := func() string {
 				return fmt.Sprintf("-%v-%v", subIns.GetGeneration(), placementRuleRv)
 			}

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -137,6 +137,7 @@ func isEqualAnnotationFiled(o, n map[string]string, key string) bool {
 
 func stringToSet(in string, sep string) map[string]struct{} {
 	out := map[string]struct{}{}
+
 	for _, w := range strings.Split(in, sep) {
 		if _, ok := out[w]; !ok {
 			out[w] = struct{}{}

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -588,13 +588,15 @@ func TestIsSubscriptionBasicChanged(t *testing.T) {
 			oldIns: &appv1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
+						//nolint
 						"apps.open-cluster-management.io/deployables": "test/pacman-subscription-0-ansible-pacman-mongo-deployment,test/pacman-subscription-0-ansible-pacman-pacman-deployment,test/pacman-subscription-0-ansible-pacman-f5-gslb-pacman-route,test/pacman-subscription-0-ansible-pacman-pacman-route,test/pacman-subscription-0-ansible-pacman-mongo-service,test/pacman-subscription-0-ansible-pacman-pacman-service,test/pacman-subscription-0-ansible-pacman-mongo-storage-persistentvolumeclaim",
 						"apps.open-cluster-management.io/git-branch":  "master",
 						"apps.open-cluster-management.io/git-commit":  "389b2a1f023caa314a4a92c3831d86bbff0acf08",
 						"apps.open-cluster-management.io/git-path":    "ansible/pacman",
-						"apps.open-cluster-management.io/topo":        "deployable//Deployment//mongo/1,deployable//Deployment//pacman/1,deployable//Route//f5-gslb-pacman/0,deployable//Route//pacman/0,deployable//Service//mongo/0,deployable//Service//pacman/0,deployable//PersistentVolumeClaim//mongo-storage/0,hook//AnsibleJob/test/service-now-nginx-demo-1-389b2a/0,hook//AnsibleJob/test/f5-update-dns-load-balancer-1-389b2a/0",
-						"open-cluster-management.io/user-group":       "c3lzdGVtOmNsdXN0ZXItYWRtaW5zLHN5c3RlbTphdXRoZW50aWNhdGVk",
-						"open-cluster-management.io/user-identity":    "a3ViZTphZG1pbg==",
+						//nolint
+						"apps.open-cluster-management.io/topo":     "deployable//Deployment//mongo/1,deployable//Deployment//pacman/1,deployable//Route//f5-gslb-pacman/0,deployable//Route//pacman/0,deployable//Service//mongo/0,deployable//Service//pacman/0,deployable//PersistentVolumeClaim//mongo-storage/0,hook//AnsibleJob/test/service-now-nginx-demo-1-389b2a/0,hook//AnsibleJob/test/f5-update-dns-load-balancer-1-389b2a/0",
+						"open-cluster-management.io/user-group":    "c3lzdGVtOmNsdXN0ZXItYWRtaW5zLHN5c3RlbTphdXRoZW50aWNhdGVk",
+						"open-cluster-management.io/user-identity": "a3ViZTphZG1pbg==",
 					},
 				},
 			},
@@ -602,13 +604,15 @@ func TestIsSubscriptionBasicChanged(t *testing.T) {
 			newIns: &appv1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
+						//nolint
 						"apps.open-cluster-management.io/deployables": "test/pacman-subscription-0-ansible-pacman-mongo-storage-persistentvolumeclaim,test/pacman-subscription-0-ansible-pacman-mongo-deployment,test/pacman-subscription-0-ansible-pacman-pacman-deployment,test/pacman-subscription-0-ansible-pacman-f5-gslb-pacman-route,test/pacman-subscription-0-ansible-pacman-pacman-route,test/pacman-subscription-0-ansible-pacman-mongo-service,test/pacman-subscription-0-ansible-pacman-pacman-service",
 						"apps.open-cluster-management.io/git-branch":  "master",
 						"apps.open-cluster-management.io/git-commit":  "389b2a1f023caa314a4a92c3831d86bbff0acf08",
 						"apps.open-cluster-management.io/git-path":    "ansible/pacman",
-						"apps.open-cluster-management.io/topo":        "deployable//Service//mongo/0,deployable//Service//pacman/0,deployable//PersistentVolumeClaim//mongo-storage/0,deployable//Deployment//mongo/1,deployable//Deployment//pacman/1,deployable//Route//f5-gslb-pacman/0,deployable//Route//pacman/0,hook//AnsibleJob/test/service-now-nginx-demo-1-389b2a/0,hook//AnsibleJob/test/f5-update-dns-load-balancer-1-389b2a/0",
-						"open-cluster-management.io/user-group":       "c3lzdGVtOmNsdXN0ZXItYWRtaW5zLHN5c3RlbTphdXRoZW50aWNhdGVk",
-						"open-cluster-management.io/user-identity":    "a3ViZTphZG1pbg==",
+						//nolint
+						"apps.open-cluster-management.io/topo":     "deployable//Service//mongo/0,deployable//Service//pacman/0,deployable//PersistentVolumeClaim//mongo-storage/0,deployable//Deployment//mongo/1,deployable//Deployment//pacman/1,deployable//Route//f5-gslb-pacman/0,deployable//Route//pacman/0,hook//AnsibleJob/test/service-now-nginx-demo-1-389b2a/0,hook//AnsibleJob/test/f5-update-dns-load-balancer-1-389b2a/0",
+						"open-cluster-management.io/user-group":    "c3lzdGVtOmNsdXN0ZXItYWRtaW5zLHN5c3RlbTphdXRoZW50aWNhdGVk",
+						"open-cluster-management.io/user-identity": "a3ViZTphZG1pbg==",
 					},
 				},
 			},

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -574,3 +574,54 @@ func TestIsEmptySubscriptionStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSubscriptionBasicChanged(t *testing.T) {
+	var tests = []struct {
+		name     string
+		expected bool
+		oldIns   *appv1.Subscription
+		newIns   *appv1.Subscription
+	}{
+		{
+			name:     "",
+			expected: false,
+			oldIns: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"apps.open-cluster-management.io/deployables": "test/pacman-subscription-0-ansible-pacman-mongo-deployment,test/pacman-subscription-0-ansible-pacman-pacman-deployment,test/pacman-subscription-0-ansible-pacman-f5-gslb-pacman-route,test/pacman-subscription-0-ansible-pacman-pacman-route,test/pacman-subscription-0-ansible-pacman-mongo-service,test/pacman-subscription-0-ansible-pacman-pacman-service,test/pacman-subscription-0-ansible-pacman-mongo-storage-persistentvolumeclaim",
+						"apps.open-cluster-management.io/git-branch":  "master",
+						"apps.open-cluster-management.io/git-commit":  "389b2a1f023caa314a4a92c3831d86bbff0acf08",
+						"apps.open-cluster-management.io/git-path":    "ansible/pacman",
+						"apps.open-cluster-management.io/topo":        "deployable//Deployment//mongo/1,deployable//Deployment//pacman/1,deployable//Route//f5-gslb-pacman/0,deployable//Route//pacman/0,deployable//Service//mongo/0,deployable//Service//pacman/0,deployable//PersistentVolumeClaim//mongo-storage/0,hook//AnsibleJob/test/service-now-nginx-demo-1-389b2a/0,hook//AnsibleJob/test/f5-update-dns-load-balancer-1-389b2a/0",
+						"open-cluster-management.io/user-group":       "c3lzdGVtOmNsdXN0ZXItYWRtaW5zLHN5c3RlbTphdXRoZW50aWNhdGVk",
+						"open-cluster-management.io/user-identity":    "a3ViZTphZG1pbg==",
+					},
+				},
+			},
+
+			newIns: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"apps.open-cluster-management.io/deployables": "test/pacman-subscription-0-ansible-pacman-mongo-storage-persistentvolumeclaim,test/pacman-subscription-0-ansible-pacman-mongo-deployment,test/pacman-subscription-0-ansible-pacman-pacman-deployment,test/pacman-subscription-0-ansible-pacman-f5-gslb-pacman-route,test/pacman-subscription-0-ansible-pacman-pacman-route,test/pacman-subscription-0-ansible-pacman-mongo-service,test/pacman-subscription-0-ansible-pacman-pacman-service",
+						"apps.open-cluster-management.io/git-branch":  "master",
+						"apps.open-cluster-management.io/git-commit":  "389b2a1f023caa314a4a92c3831d86bbff0acf08",
+						"apps.open-cluster-management.io/git-path":    "ansible/pacman",
+						"apps.open-cluster-management.io/topo":        "deployable//Service//mongo/0,deployable//Service//pacman/0,deployable//PersistentVolumeClaim//mongo-storage/0,deployable//Deployment//mongo/1,deployable//Deployment//pacman/1,deployable//Route//f5-gslb-pacman/0,deployable//Route//pacman/0,hook//AnsibleJob/test/service-now-nginx-demo-1-389b2a/0,hook//AnsibleJob/test/f5-update-dns-load-balancer-1-389b2a/0",
+						"open-cluster-management.io/user-group":       "c3lzdGVtOmNsdXN0ZXItYWRtaW5zLHN5c3RlbTphdXRoZW50aWNhdGVk",
+						"open-cluster-management.io/user-identity":    "a3ViZTphZG1pbg==",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual := IsSubscriptionBasicChanged(tt.oldIns, tt.newIns)
+			if actual != tt.expected {
+				t.Errorf("(%s): expected %v, actual %v", tt.name, tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This one is fixing  [issue](https://github.com/open-cluster-management/backlog/issues/6324#event-3900786694)
1. the reconcile loop on the `utils.IsSubscriptionBasicChanged`, we are going to compare the `deployables` and `topo` annotation to make sure the generated string order is ignored.

2. making sure the `overridePrehookTopoAnnotation` only happens when the prehook is at incompleted stage. The previous flow would trigger the annotation updates too often.

3. revert the logic of `registryJobs`, instead using [logic](https://github.com/open-cluster-management/multicloud-operators-subscription/compare/fix-deep-equal-of-annotation?expand=1#diff-4f94b29559d529e700fb0f1fcc5308777d55ec0f63a228b2d493a8e25c2c04c7R81), since the current version would skip the creation of pre and post hook.

The duplicate is coming from the following logic:
```
	if getCommitID(subIns) != "" && !forceRegister && !a.isSubscriptionUpdate(subIns, a.isSubscriptionSpecChange, isCommitIDNotEqual) {
		return nil
	}
```
When bout the commitID and forceRegister changed, our recent modification won't cover it, we might need to revisit it later.
