### PR TITLE
skip the target_clusters dupe ansible job check if commitID has been changed

### DIFF
--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -51,7 +51,8 @@ type appliedJobs struct {
 
 func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 	suffixFunc SuffixFunc, jobs []ansiblejob.AnsibleJob, kubeclient client.Client,
-	logger logr.Logger, forceRegister bool, placementRuleRv string, hookType string) error {
+	logger logr.Logger, placementDecisionUpdated bool, placementRuleRv string, hookType string,
+	commitIDChanged bool) error {
 	for _, job := range jobs {
 		jobKey := types.NamespacedName{Name: job.GetName(), Namespace: job.GetNamespace()}
 		ins, err := overrideAnsibleInstance(subIns, job, kubeclient, logger, hookType)
@@ -78,14 +79,14 @@ func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 		jobRecords.mux.Lock()
 		jobRecords.Original = ins
 
-		if forceRegister && len(jobRecords.Instance) != 0 {
+		if placementDecisionUpdated && len(jobRecords.Instance) != 0 {
 			plrSuffixFunc := func() string {
 				return fmt.Sprintf("-%v-%v", subIns.GetGeneration(), placementRuleRv)
 			}
 
 			suffix = plrSuffixFunc()
 
-			logger.Info("forceRegister suffix is: " + suffix)
+			logger.V(DebugLog).Info("placementDecisionUpdated suffix is: " + suffix)
 		}
 
 		nx.SetName(fmt.Sprintf("%s%s", nx.GetName(), suffix))
@@ -95,7 +96,7 @@ func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 		logger.Info(fmt.Sprintf("registered ansiblejob %s", nxKey))
 
 		if _, ok := jobRecords.InstanceSet[nxKey]; !ok {
-			if forceRegister && len(jobRecords.Instance) > 0 {
+			if !commitIDChanged && placementDecisionUpdated && len(jobRecords.Instance) > 0 {
 				lastJob := jobRecords.Instance[len(jobRecords.Instance)-1]
 
 				// if the last job is running (or already done)

--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -96,7 +96,11 @@ func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 		logger.Info(fmt.Sprintf("registered ansiblejob %s", nxKey))
 
 		if _, ok := jobRecords.InstanceSet[nxKey]; !ok {
-			if !commitIDChanged && placementDecisionUpdated && len(jobRecords.Instance) > 0 {
+			jobRecordsInstancePopulated := len(jobRecords.Instance) > 0
+
+			if !commitIDChanged && placementDecisionUpdated && jobRecordsInstancePopulated {
+				logger.V(DebugLog).Info("Checking to see AnsibleJob should be created...")
+
 				lastJob := jobRecords.Instance[len(jobRecords.Instance)-1]
 
 				// if the last job is running (or already done)
@@ -139,6 +143,10 @@ func (jIns *JobInstances) registryJobs(gClt GitOps, subIns *subv1.Subscription,
 
 					continue
 				}
+			} else {
+				logger.Info(fmt.Sprintf("Skipping duplicated AnsibleJob creation check..."+
+					" commitIDChanged=%v placementDecisionUpdated=%v jobRecordsInstancePopulated=%v",
+					commitIDChanged, placementDecisionUpdated, jobRecordsInstancePopulated))
 			}
 
 			jobRecords.InstanceSet[nxKey] = struct{}{}

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -461,11 +461,11 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result rec
 	passedPrehook := true
 
 	//flag used to determine if the reconcile came from a placementrule decision change then force register
-	forceRegister := false
+	placementDecisionUpdated := false
 	placementRuleRv := ""
 
 	if strings.Contains(request.Name, placementRuleFlag) {
-		forceRegister = true
+		placementDecisionUpdated = true
 		placementRuleRv = after(request.Name, placementRuleFlag)
 		request.Name = strings.TrimSuffix(request.Name, placementRuleRv)
 		request.Name = strings.TrimSuffix(request.Name, placementRuleFlag)
@@ -520,7 +520,7 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result rec
 	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) {
 		r.hubGitOps.RegisterBranch(instance)
 		// register will skip the failed clone repo
-		if err := r.hooks.RegisterSubscription(instance, forceRegister, placementRuleRv); err != nil {
+		if err := r.hooks.RegisterSubscription(instance, placementDecisionUpdated, placementRuleRv); err != nil {
 			logger.Error(err, "failed to register hooks, skip the subscription reconcile")
 			preErr = fmt.Errorf("failed to register hooks, err: %v", err)
 

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -681,13 +681,6 @@ func (r *ReconcileSubscription) IsSubscriptionCompleted(subKey types.NamespacedN
 		}
 
 		for pkg, pSt := range cSt.SubscriptionPackageStatus {
-			//pSt.ResourceStatus == nil is used to prevent the initialize error
-			if pSt.ResourceStatus == nil || string(pSt.ResourceStatus.Raw) == "{}" {
-				r.logger.Error(fmt.Errorf("cluster %s package %s's resources %s", cluster,
-					pkg, pSt.ResourceStatus), "subscription is not completed")
-				return false, nil
-			}
-
 			if pSt.Phase != subv1.SubscriptionSubscribed {
 				r.logger.Error(fmt.Errorf("cluster %s package %s is at status %s", cluster, pkg, pSt.Phase),
 					"subscription is not completed")


### PR DESCRIPTION
For https://github.com/open-cluster-management/backlog/issues/6324

It seems like new ansiblejobs are no longer fired if the commit has been changed (but `target_clusters` remain the same)
I think ansiblejobs should always fired if there is a commit and we detected it.

Signed-off-by: Mike Ng <ming@redhat.com>