### PR TITLE
Fix customize override in multiple subscriptions using the same channel

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -469,12 +469,8 @@ func (r *ReconcileSubscription) subscribeKustomizations(chn *chnv1.Channel, sub 
 		for _, ov := range sub.Spec.PackageOverrides {
 			ovKustomizeDir := strings.Split(ov.PackageName, "kustomization")[0]
 
-			// If the kustomization path is not specified, use the current path
-			if ovKustomizeDir == "" {
-				ovKustomizeDir = relativePath
-			}
-
-			if !strings.EqualFold(ovKustomizeDir, relativePath) {
+			//If the full kustomization.yaml path is specified but different than the current kustomize dir, egnore
+			if !strings.EqualFold(ovKustomizeDir, relativePath) && !strings.EqualFold(ovKustomizeDir, "") {
 				continue
 			} else {
 				klog.Info("Overriding kustomization ", kustomizeDir)

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -468,6 +468,12 @@ func (r *ReconcileSubscription) subscribeKustomizations(chn *chnv1.Channel, sub 
 
 		for _, ov := range sub.Spec.PackageOverrides {
 			ovKustomizeDir := strings.Split(ov.PackageName, "kustomization")[0]
+
+			// If the kustomization path is not specified, use the current path
+			if ovKustomizeDir == "" {
+				ovKustomizeDir = relativePath
+			}
+
 			if !strings.EqualFold(ovKustomizeDir, relativePath) {
 				continue
 			} else {

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -289,11 +289,8 @@ func setBranch(subIns *subv1.Subscription, bName string) {
 	subIns.SetAnnotations(an)
 }
 
-func genRepoName(repoURL, user, pwd string) string {
-	repoName := repoURL
-	if pwd != "" {
-		repoName += user
-	}
+func genRepoName(subName, subNamespace string) string {
+	repoName := subName + subNamespace
 
 	return repoName
 }
@@ -328,7 +325,10 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) {
 	}
 
 	repoURL := channel.Spec.Pathname
-	repoName := genRepoName(repoURL, user, pwd)
+	// repoName is the key of a map that stores repository information for subscription.
+	// It needs to be unique for each subscription because each subscription need to
+	// have its own copy of cloned repo to work on subscription specific overrides.
+	repoName := genRepoName(subIns.Name, subIns.Namespace)
 	branchName := genBranchString(subIns)
 	repoBranchDir := h.downloadDirResolver(channel, subIns)
 

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -222,8 +222,11 @@ func (ghsi *SubscriberItem) subscribeKustomizations() error {
 		for _, ov := range ghsi.Subscription.Spec.PackageOverrides {
 			ovKustomizeDir := strings.Split(ov.PackageName, "kustomization")[0]
 
-			//If the full kustomization.yaml path is specified but different than the current kustomize dir, egnore
-			if !strings.EqualFold(ovKustomizeDir, relativePath) && !strings.EqualFold(ovKustomizeDir, "") {
+			if ovKustomizeDir == "" {
+				ovKustomizeDir = relativePath
+			}
+
+			if !strings.EqualFold(ovKustomizeDir, relativePath) {
 				continue
 			} else {
 				klog.Info("Overriding kustomization ", kustomizeDir)

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -222,11 +222,8 @@ func (ghsi *SubscriberItem) subscribeKustomizations() error {
 		for _, ov := range ghsi.Subscription.Spec.PackageOverrides {
 			ovKustomizeDir := strings.Split(ov.PackageName, "kustomization")[0]
 
-			if ovKustomizeDir == "" {
-				ovKustomizeDir = relativePath
-			}
-
-			if !strings.EqualFold(ovKustomizeDir, relativePath) {
+			//If the full kustomization.yaml path is specified but different than the current kustomize dir, egnore
+			if !strings.EqualFold(ovKustomizeDir, relativePath) && !strings.EqualFold(ovKustomizeDir, "") {
 				continue
 			} else {
 				klog.Info("Overriding kustomization ", kustomizeDir)


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6476

In subscription, you can override the kustomization.yaml by doing

```
  packageOverrides:
  - packageName: kustomization
    packageOverrides:
    - value:
        namespace: provider
        resources:
        - service.yaml
        - deployment-local.yaml
```

For the git subscription sync, it required the packageName to contain the path to the target kustomization.yaml file relative to the root of the Git repo. This should not be required because the Git path is already defined in subscription's annotation.

Also, there was a regression problem that when multiple subscriptions share the same Git channel with the same branch, the subscriptions do not get its own copy of the repo content so subscription specific overrides did not work.