### PR TITLE
Support skip cert verify

### DIFF
--- a/deploy/standalone/apps.open-cluster-management.io_channels_crd.yaml
+++ b/deploy/standalone/apps.open-cluster-management.io_channels_crd.yaml
@@ -144,6 +144,10 @@ spec:
                 URL for the channel contents; For a `objectbucket` channel, pathname
                 is the URL and name of the bucket.
               type: string
+            insecureSkipVerify:
+              description: Skip server TLS certificate verification for Git or Helm
+                channel.
+              type: boolean
             secretRef:
               description: For a `github` channel or a `helmrepo` channel on github,
                 this can be used to reference a Secret which contains the credentials

--- a/docs/gitrepo_subscription.md
+++ b/docs/gitrepo_subscription.md
@@ -171,7 +171,7 @@ spec:
       name: my-git-secret
 ```
 
-## Subscribing to a self-hosted Git repository with custom or self-signed TLS certificate
+## Subscribing to a self-hosted Git server with custom or self-signed TLS certificate
 
 If a Git server has a custom or self-signed TLS certificate, you need to associate the channel with a config map to skip the certificate verification. Otherwise, the connection to the Git server will fail with an error similar to the following.
 

--- a/docs/gitrepo_subscription.md
+++ b/docs/gitrepo_subscription.md
@@ -171,6 +171,40 @@ spec:
       name: my-git-secret
 ```
 
+## Subscribing to a self-hosted Git repository with custom or self-signed TLS certificate
+
+If a Git server has a custom or self-signed TLS certificate, you need to associate the channel with a config map to skip the certificate verification. Otherwise, the connection to the Git server will fail with an error similar to the following.
+
+```
+x509: certificate is valid for localhost.com, not localhost
+```
+
+Update you channel resource to reference a Kubernetes config map and define the YAML content to skip certificate verification. The `data` section of the config map must contain `insecureSkipVerify: "true"`.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skip-cert-verify
+  namespace: sample
+data:
+  insecureSkipVerify: "true"
+---
+apiVersion: apps.open-cluster-management.io/v1
+ind: Channel
+metadata:
+labels:
+  name: sample-channel
+  namespace: sample
+spec:
+  type: GitHub
+  pathname: <Git URL>
+  configMapRef:
+    name: skip-cert-verify
+    apiVersion: v1
+    kind: ConfigMap
+```
+
 ## .kubernetesignore file
 
 You can include a `.kubernetesignore` file within your Git repository root directory, or within the `data.path` directory that is specified in the ConfigMap that is defined for your subscription `spec.packageFilter.filterRef` field.

--- a/docs/gitrepo_subscription.md
+++ b/docs/gitrepo_subscription.md
@@ -173,23 +173,13 @@ spec:
 
 ## Subscribing to a self-hosted Git server with custom or self-signed TLS certificate
 
-If a Git server has a custom or self-signed TLS certificate, you need to associate the channel with a config map to skip the certificate verification. Otherwise, the connection to the Git server will fail with an error similar to the following.
+If a Git server has a custom or self-signed TLS certificate, you can use `insecureSkipVerify: true` in the channel spec. Otherwise, the connection to the Git server will fail with an error similar to the following.
 
 ```
 x509: certificate is valid for localhost.com, not localhost
 ```
 
-Update you channel resource to reference a Kubernetes config map and define the YAML content to skip certificate verification. The `data` section of the config map must contain `insecureSkipVerify: "true"`.
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: skip-cert-verify
-  namespace: sample
-data:
-  insecureSkipVerify: "true"
----
+```
 apiVersion: apps.open-cluster-management.io/v1
 ind: Channel
 metadata:
@@ -199,10 +189,7 @@ labels:
 spec:
   type: GitHub
   pathname: <Git URL>
-  configMapRef:
-    name: skip-cert-verify
-    apiVersion: v1
-    kind: ConfigMap
+  insecureSkipVerify: true
 ```
 
 ## .kubernetesignore file

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/open-cluster-management/ansiblejob-go-lib v0.1.12
 	github.com/open-cluster-management/api v0.0.0-20200623215229-19a96fed707a
-	github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20200813201238-cf522bb8e5a9
+	github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20201103204539-9d9004e1f5e6
 	github.com/open-cluster-management/multicloud-operators-deployable v0.0.0-20200817152717-50b364f569c6
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-2020-06-08-14-28-27.0.20200817152733-689893a33a7f
 	github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20200819124024-818f01d780ff

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,8 @@ github.com/open-cluster-management/api v0.0.0-20200623215229-19a96fed707a h1:pn5
 github.com/open-cluster-management/api v0.0.0-20200623215229-19a96fed707a/go.mod h1:+vUECYB7WkfCb52r0J7rxgD1mseSGAqGi8rTLLRcbgw=
 github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20200813201238-cf522bb8e5a9 h1:vgRLkMnoHybo44omfnBC6Ozb8TbxmoAvb5zJzS7OYVA=
 github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20200813201238-cf522bb8e5a9/go.mod h1:aMAmygx4m9e4CBT5hfWcguCA3IeSe5LfrQnjEYkWvoM=
+github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20201103204539-9d9004e1f5e6 h1:xxRcdDt4gMkxbWhFDkhk8Z2K3UKGSiw8RUS33rH9gZg=
+github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20201103204539-9d9004e1f5e6/go.mod h1:aMAmygx4m9e4CBT5hfWcguCA3IeSe5LfrQnjEYkWvoM=
 github.com/open-cluster-management/multicloud-operators-deployable v0.0.0-20200625020633-0d458afa0fc2/go.mod h1:aC7GU06KWzaMmtnodm+WmUzQZUS/Uwz63D/32/Dypf8=
 github.com/open-cluster-management/multicloud-operators-deployable v0.0.0-20200817152717-50b364f569c6 h1:h9t7/Ro5JFus0jSb2UhnKFyWgloKafuX3dY7NcvR5Mk=
 github.com/open-cluster-management/multicloud-operators-deployable v0.0.0-20200817152717-50b364f569c6/go.mod h1:4iDd0TpKuchLyeUcoIv+EDt0xpZQFSUtTA78VaJywag=

--- a/pkg/controller/mcmhub/hook_suite_test.go
+++ b/pkg/controller/mcmhub/hook_suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func(done Done) {
 		return defaultCommit, nil
 	}
 
-	cloneFunc := func(string, string, string, string, string) (string, error) {
+	cloneFunc := func(string, string, string, string, string, bool) (string, error) {
 		return defaultCommit, nil
 	}
 

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -71,7 +71,7 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1alpha1.Subscription)
 	case chnv1alpha1.ChannelTypeGit, chnv1alpha1.ChannelTypeGitHub:
 		updateSubDplAnno, err = r.UpdateGitDeployablesAnnotation(sub)
 	case chnv1alpha1.ChannelTypeHelmRepo:
-		updateSubDplAnno = UpdateHelmTopoAnnotation(r.Client, r.cfg, sub)
+		updateSubDplAnno = UpdateHelmTopoAnnotation(r.Client, r.cfg, sub, channel.Spec.InsecureSkipVerify)
 	default:
 		updateSubDplAnno = r.UpdateDeployablesAnnotation(sub)
 	}

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -337,6 +337,8 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) {
 			if err != nil {
 				klog.Error(err, "Unable to parse insecureSkipVerify: ", channelConfigMap.Data["insecureSkipVerify"])
 			}
+
+			h.logger.Info("Channel config map found with insecureSkipVerify: " + channelConfigMap.Data["insecureSkipVerify"])
 		}
 	}
 

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,7 +34,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -327,19 +325,11 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) {
 		return
 	}
 
-	channelConfigMap := utils.GetChannelConfigMap(h.clt, channel)
 	skipCertVerify := false
 
-	if channelConfigMap != nil {
-		if channelConfigMap.Data["insecureSkipVerify"] != "" {
-			skipCertVerify, err = strconv.ParseBool(channelConfigMap.Data["insecureSkipVerify"])
-
-			if err != nil {
-				klog.Error(err, "Unable to parse insecureSkipVerify: ", channelConfigMap.Data["insecureSkipVerify"])
-			}
-
-			h.logger.Info("Channel config map found with insecureSkipVerify: " + channelConfigMap.Data["insecureSkipVerify"])
-		}
+	if channel.Spec.InsecureSkipVerify {
+		skipCertVerify = true
+		h.logger.Info("Channel spec has insecureSkipVerify: true.")
 	}
 
 	repoURL := channel.Spec.Pathname

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -329,6 +329,7 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) {
 
 	if channel.Spec.InsecureSkipVerify {
 		skipCertVerify = true
+
 		h.logger.Info("Channel spec has insecureSkipVerify: true.")
 	}
 

--- a/pkg/controller/mcmhub/metaupdate.go
+++ b/pkg/controller/mcmhub/metaupdate.go
@@ -62,13 +62,13 @@ func ObjectString(obj metav1.Object) string {
 	return fmt.Sprintf("%v/%v", obj.GetNamespace(), obj.GetName())
 }
 
-func UpdateHelmTopoAnnotation(hubClt client.Client, hubCfg *rest.Config, sub *subv1.Subscription) bool {
+func UpdateHelmTopoAnnotation(hubClt client.Client, hubCfg *rest.Config, sub *subv1.Subscription, insecureSkipVeriy bool) bool {
 	subanno := sub.GetAnnotations()
 	if len(subanno) == 0 {
 		subanno = make(map[string]string)
 	}
 
-	helmRls, err := helmops.GetSubscriptionChartsOnHub(hubClt, sub)
+	helmRls, err := helmops.GetSubscriptionChartsOnHub(hubClt, sub, insecureSkipVeriy)
 	if err != nil {
 		klog.Errorf("failed to get the chart index for helm subscription %v, err: %v", ObjectString(sub), err)
 		return false

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -526,7 +526,13 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 		}
 	}
 
-	return utils.CloneGitRepo(ghsi.Channel.Spec.Pathname, utils.GetSubscriptionBranch(ghsi.Subscription), user, token, ghsi.repoRoot, ghsi.Channel.Spec.InsecureSkipVerify)
+	return utils.CloneGitRepo(
+		ghsi.Channel.Spec.Pathname,
+		utils.GetSubscriptionBranch(ghsi.Subscription),
+		user,
+		token,
+		ghsi.repoRoot,
+		ghsi.Channel.Spec.InsecureSkipVerify)
 }
 
 func (ghsi *SubscriberItem) sortClonedGitRepo() error {

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -528,6 +528,8 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 				klog.Error(err, "Unable to parse insecureSkipVerify: ", ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
 				return "", err
 			}
+
+			klog.Info("Channel config map found with insecureSkipVerify: " + ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
 		}
 	}
 

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -518,20 +517,6 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 
 	user := ""
 	token := ""
-	insecureSkipVerify := false
-
-	if ghsi.SubscriberItem.ChannelConfigMap != nil {
-		if ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"] != "" {
-			insecureSkipVerify, err = strconv.ParseBool(ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
-
-			if err != nil {
-				klog.Error(err, "Unable to parse insecureSkipVerify: ", ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
-				return "", err
-			}
-
-			klog.Info("Channel config map found with insecureSkipVerify: " + ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
-		}
-	}
 
 	if ghsi.SubscriberItem.ChannelSecret != nil {
 		user, token, err = utils.ParseChannelSecret(ghsi.SubscriberItem.ChannelSecret)
@@ -541,7 +526,7 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 		}
 	}
 
-	return utils.CloneGitRepo(ghsi.Channel.Spec.Pathname, utils.GetSubscriptionBranch(ghsi.Subscription), user, token, ghsi.repoRoot, insecureSkipVerify)
+	return utils.CloneGitRepo(ghsi.Channel.Spec.Pathname, utils.GetSubscriptionBranch(ghsi.Subscription), user, token, ghsi.repoRoot, ghsi.Channel.Spec.InsecureSkipVerify)
 }
 
 func (ghsi *SubscriberItem) sortClonedGitRepo() error {

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -517,6 +518,18 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 
 	user := ""
 	token := ""
+	insecureSkipVerify := false
+
+	if ghsi.SubscriberItem.ChannelConfigMap != nil {
+		if ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"] != "" {
+			insecureSkipVerify, err = strconv.ParseBool(ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
+
+			if err != nil {
+				klog.Error(err, "Unable to parse insecureSkipVerify: ", ghsi.SubscriberItem.ChannelConfigMap.Data["insecureSkipVerify"])
+				return "", err
+			}
+		}
+	}
 
 	if ghsi.SubscriberItem.ChannelSecret != nil {
 		user, token, err = utils.ParseChannelSecret(ghsi.SubscriberItem.ChannelSecret)
@@ -526,7 +539,7 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 		}
 	}
 
-	return utils.CloneGitRepo(ghsi.Channel.Spec.Pathname, utils.GetSubscriptionBranch(ghsi.Subscription), user, token, ghsi.repoRoot)
+	return utils.CloneGitRepo(ghsi.Channel.Spec.Pathname, utils.GetSubscriptionBranch(ghsi.Subscription), user, token, ghsi.repoRoot, insecureSkipVerify)
 }
 
 func (ghsi *SubscriberItem) sortClonedGitRepo() error {

--- a/pkg/subscriber/git/git_subscriber_test.go
+++ b/pkg/subscriber/git/git_subscriber_test.go
@@ -151,24 +151,6 @@ var (
 			Channel: bitbucketsharedkey.String(),
 		},
 	}
-	skipCertCfgMapKey = types.NamespacedName{
-		Name:      "skip-cert-verify",
-		Namespace: bitbucketsharedkey.Namespace,
-	}
-
-	skipCertCfgMap = &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      skipCertCfgMapKey.Name,
-			Namespace: skipCertCfgMapKey.Namespace,
-		},
-		Data: map[string]string{
-			"insecureSkipVerify": "true",
-		},
-	}
 )
 
 var _ = Describe("github subscriber reconcile logic", func() {
@@ -287,8 +269,8 @@ var _ = Describe("test subscribing to bitbucket repository", func() {
 	It("should be able to clone the bitbucket repo with skip certificate verificationand sort resources", func() {
 		subitem := &SubscriberItem{}
 		subitem.Subscription = bitbucketsub
+		bitbucketchn.Spec.InsecureSkipVerify = true
 		subitem.Channel = bitbucketchn
-		subitem.ChannelConfigMap = skipCertCfgMap
 		subitem.synchronizer = defaultSubscriber.synchronizer
 		commitid, err := subitem.cloneGitRepo()
 		Expect(commitid).ToNot(Equal(""))

--- a/pkg/subscriber/git/git_subscriber_test.go
+++ b/pkg/subscriber/git/git_subscriber_test.go
@@ -297,7 +297,7 @@ var _ = Describe("test subscribing to bitbucket repository", func() {
 		err = subitem.sortClonedGitRepo()
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(len(subitem.indexFile.Entries)).To(Equal(2))
+		Expect(len(subitem.indexFile.Entries)).To(Equal(3))
 
 		Expect(len(subitem.crdsAndNamespaceFiles)).To(Equal(2))
 		Expect(len(subitem.rbacFiles)).To(Equal(3))

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -277,6 +277,11 @@ func (hrsi *SubscriberItem) processSubscription(indexFile *repo.IndexFile, hash 
 
 func getHelmRepoClient(chnCfg *corev1.ConfigMap, insecureSkipVerify bool) (*http.Client, error) {
 	client := http.DefaultClient
+
+	if insecureSkipVerify {
+		klog.Info("Channel spec has insecureSkipVerify: true. Skipping Helm repo server certificate verification.")
+	}
+
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -295,7 +300,7 @@ func getHelmRepoClient(chnCfg *corev1.ConfigMap, insecureSkipVerify bool) (*http
 		},
 	}
 
-	if chnCfg != nil {
+	if chnCfg != nil && !insecureSkipVerify {
 		helmRepoConfigData := chnCfg.Data
 		klog.V(5).Infof("s.HelmRepoConfig.Data %v", helmRepoConfigData)
 

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -312,6 +312,10 @@ func getHelmRepoClient(chnCfg *corev1.ConfigMap, insecureSkipVerify bool) (*http
 			}
 
 			transport.TLSClientConfig.InsecureSkipVerify = b
+
+			if b {
+				klog.Info("Channel has config map with insecureSkipVerify: true. Skipping Helm repo server certificate verification.")
+			}
 		} else {
 			klog.V(5).Info("helmRepoConfigData[\"insecureSkipVerify\"] is empty")
 		}

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -288,8 +288,9 @@ func getHelmRepoClient(chnCfg *corev1.ConfigMap, insecureSkipVerify bool) (*http
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		/* #nosec G402 */
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: insecureSkipVerify,
+			InsecureSkipVerify: insecureSkipVerify, // #nosec G402 InsecureSkipVerify optionally
 			MinVersion:         tls.VersionTLS12,
 		},
 	}

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -127,7 +127,7 @@ func CloneGitRepo(repoURL string, branch plumbing.ReferenceName, user, password,
 
 		customClient := &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
 			},
 
 			// 15 second timeout

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -126,6 +126,7 @@ func CloneGitRepo(repoURL string, branch plumbing.ReferenceName, user, password,
 		klog.Info("insecureSkipVerify = true, skipping Git server's certificate verification.")
 
 		customClient := &http.Client{
+			/* #nosec G402 */
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, // #nosec G402 InsecureSkipVerify conditionally
 			},

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -124,6 +124,7 @@ func CloneGitRepo(repoURL string, branch plumbing.ReferenceName, user, password,
 	// skip TLS certificate verification for Git servers with custom or self-signed certs
 	if insecureSkipVerify {
 		klog.Info("insecureSkipVerify = true, skipping Git server's certificate verification.")
+
 		customClient := &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -127,7 +127,7 @@ func CloneGitRepo(repoURL string, branch plumbing.ReferenceName, user, password,
 
 		customClient := &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, // #nosec G402 InsecureSkipVerify conditionally
 			},
 
 			// 15 second timeout

--- a/pkg/webhook/listener/webhook_listner.go
+++ b/pkg/webhook/listener/webhook_listner.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
@@ -138,12 +137,14 @@ func CreateWebhookListener(config,
 
 	var err error
 
+	klog.Info("ROKEROKE 1")
 	dynamicClient := dynamic.NewForConfigOrDie(config)
 
 	l := &WebhookListener{
 		DynamicClient: dynamicClient,
 		localConfig:   config,
 	}
+	klog.Info("ROKEROKE 2")
 
 	// The user-provided key and cert files take precedence over the default provided files if both sets exist.
 	if _, err := os.Stat(defaultKeyFile); err == nil {
@@ -164,6 +165,8 @@ func CreateWebhookListener(config,
 
 	l.LocalClient, err = client.New(config, client.Options{})
 
+	klog.Info("ROKEROKE 3")
+
 	if err != nil {
 		klog.Error("Failed to initialize client to update local status. error: ", err)
 		return nil, err
@@ -179,7 +182,9 @@ func CreateWebhookListener(config,
 		}
 	}
 
-	if createService {
+	klog.Info("ROKEROKE 4")
+
+	/*if createService {
 		namespace, err := k8sutil.GetOperatorNamespace()
 
 		if err != nil {
@@ -193,7 +198,7 @@ func CreateWebhookListener(config,
 			klog.Error("Failed to create a service for Git webhook listener. error: ", err)
 			return nil, err
 		}
-	}
+	}*/
 
 	return l, err
 }

--- a/pkg/webhook/listener/webhook_listner.go
+++ b/pkg/webhook/listener/webhook_listner.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
@@ -137,14 +138,12 @@ func CreateWebhookListener(config,
 
 	var err error
 
-	klog.Info("ROKEROKE 1")
 	dynamicClient := dynamic.NewForConfigOrDie(config)
 
 	l := &WebhookListener{
 		DynamicClient: dynamicClient,
 		localConfig:   config,
 	}
-	klog.Info("ROKEROKE 2")
 
 	// The user-provided key and cert files take precedence over the default provided files if both sets exist.
 	if _, err := os.Stat(defaultKeyFile); err == nil {
@@ -165,8 +164,6 @@ func CreateWebhookListener(config,
 
 	l.LocalClient, err = client.New(config, client.Options{})
 
-	klog.Info("ROKEROKE 3")
-
 	if err != nil {
 		klog.Error("Failed to initialize client to update local status. error: ", err)
 		return nil, err
@@ -182,9 +179,7 @@ func CreateWebhookListener(config,
 		}
 	}
 
-	klog.Info("ROKEROKE 4")
-
-	/*if createService {
+	if createService {
 		namespace, err := k8sutil.GetOperatorNamespace()
 
 		if err != nil {
@@ -198,7 +193,7 @@ func CreateWebhookListener(config,
 			klog.Error("Failed to create a service for Git webhook listener. error: ", err)
 			return nil, err
 		}
-	}*/
+	}
 
 	return l, err
 }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6404

The ACM subscription controller cannot connect to a private Git repo with a self-signed certificate because the cert is not trusted during TLS connection. There should be a way to either skip the cert verification or add the certificate to a certificate store.

You can specify `insecureSkipVerify: true` in the channel spec.

```
apiVersion: apps.open-cluster-management.io/v1
ind: Channel
metadata:
labels:
  name: sample-channel
  namespace: sample
spec:
  type: GitHub
  pathname: <Git URL>
  insecureSkipVerify: true
```