### PR TITLE
make sure the git watch could get commit id when the client has private git host

### DIFF
--- a/examples/e2e_example/self-host-git.yaml
+++ b/examples/e2e_example/self-host-git.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: git-sub-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ch-git
+---
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: git-sub-app
+  namespace: git-sub-ns
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchLabels:
+      name: git-sub
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: git
+  namespace: ch-git
+  labels:
+    name: git-sub
+spec:
+  type: Git
+  pathname: https://try.gogs.io/wzhan366/random-git.git
+  secretRef:
+    name: dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dev
+  namespace: ch-git
+data:
+  user: <base64 encode string>
+  accessToken: <base64 encode string>
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: towhichcluster
+  namespace: git-sub-ns
+  labels:
+    name: git-sub
+spec:
+  clusterReplicas: 1
+  clusterLabels:
+    matchLabels:
+      name: spoke
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: git-sub
+  namespace: git-sub-ns
+  labels:
+    name: git-sub
+  annotations:
+    apps.open-cluster-management.io/github-path: git-ops/bookinfo/guestbook
+spec:
+  channel: ch-git/git
+  placement:
+    placementRef: 
+      name: towhichcluster
+

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -90,8 +90,12 @@ type RepoRegistery struct {
 	branchs map[string]*branchInfo
 }
 
-type GetCommitFunc func(string, string, string, string) (string, error)
-type cloneFunc func(string, string, string, string, string, bool) (string, error)
+type GetCommitFunc func(url string, branchName string, user string, secret string) (string, error)
+
+type cloneFunc func(url string, branchName string, user string, secret string,
+	localDir string, insecureSkipVerify bool) (string, error)
+
+type dirResolver func(*chnv1.Channel, *subv1.Subscription) string
 
 type HubGitOps struct {
 	clt                 client.Client
@@ -100,7 +104,7 @@ type HubGitOps struct {
 	watcherInterval     time.Duration
 	subRecords          map[types.NamespacedName]string
 	repoRecords         map[string]*RepoRegistery
-	downloadDirResolver func(*chnv1.Channel, *subv1.Subscription) string
+	downloadDirResolver dirResolver
 	getCommitFunc       GetCommitFunc
 	cloneFunc           cloneFunc
 }
@@ -185,7 +189,12 @@ func (h *HubGitOps) GitWatch() {
 			nCommit, err := h.getCommitFunc(url, bName, branchInfo.username, branchInfo.secret)
 
 			if err != nil {
-				h.logger.Error(err, "failed to get the latest commit id")
+				h.logger.Error(err, "failed to get the latest commit id via API, will try to get the commit ID by clone")
+
+				nCommit, err = h.cloneFunc(url, bName, branchInfo.username, branchInfo.secret, branchInfo.localDir, branchInfo.insecureSkipVerify)
+				if err != nil {
+					h.logger.Error(err, "failed to get the latest commit id by clone the repo")
+				}
 			}
 
 			// safe guard condition to filter out the edge case
@@ -446,9 +455,9 @@ func (h *HubGitOps) DeregisterBranch(subKey types.NamespacedName) {
 	}
 }
 
-func GetLatestRemoteGitCommitID(repo, branch, secret, pwd string) (string, error) {
+func GetLatestRemoteGitCommitID(repo, branch, user, pwd string) (string, error) {
 	tp := github.BasicAuthTransport{
-		Username: strings.TrimSpace(secret),
+		Username: strings.TrimSpace(user),
 		Password: strings.TrimSpace(pwd),
 	}
 

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -472,6 +472,10 @@ func (h *HubGitOps) GetLatestCommitID(subIns *subv1.Subscription) (string, error
 		h.RegisterBranch(subIns)
 	}
 
+	if len(h.repoRecords) == 0 {
+		return "", fmt.Errorf("failed to register the branch")
+	}
+
 	repoName := h.subRecords[subKey]
 
 	return h.repoRecords[repoName].branchs[genBranchString(subIns)].lastCommitID, nil


### PR DESCRIPTION
Addressing issue:

https://bugzilla.redhat.com/show_bug.cgi?id=1896341

Will try to get the commit id by clone when calling to RESTFull request fails.

Signed-off-by: Ian Zhang <izhang@redhat.com>