### PR TITLE
Fix time window status change from active to blocked

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -221,6 +221,8 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 					instance.Status.Message = subscriptionBlock
 				}
 				nextStatusUpateAt = utils.NextStatusReconcile(instance.Spec.TimeWindow, r.clk())
+
+				klog.Infof("Next time window status reconciliation will occur in " + nextStatusUpateAt.String())
 			}
 
 			err = r.Status().Update(context.TODO(), instance)

--- a/pkg/utils/timewindow.go
+++ b/pkg/utils/timewindow.go
@@ -57,7 +57,7 @@ func NextStatusReconcile(tw *appv1alpha1.TimeWindow, t time.Time) time.Duration 
 
 	if IsInWindow(tw, uniCurTime) {
 		vHr := validateHourRange(tw.Hours, getLoc(tw.Location))
-		vdays, rveDays := validateDaysofweekSlice(tw.Daysofweek)
+		vdays, _ := validateDaysofweekSlice(tw.Daysofweek)
 		rvevHr := reverseRange(vHr, getLoc(tw.Location))
 
 		// If currently not blocked but the time window type is `blocked`, we need to get the next time
@@ -66,7 +66,8 @@ func NextStatusReconcile(tw *appv1alpha1.TimeWindow, t time.Time) time.Duration 
 			return generateNextPoint(vHr, vdays, uniCurTime, false) + 1*time.Minute
 		}
 
-		return generateNextPoint(rvevHr, rveDays, uniCurTime, false) + 1*time.Minute
+		// The window type is active so we need to get the next time it should be blocked.
+		return generateNextPoint(rvevHr, vdays, uniCurTime, false) + 1*time.Minute
 	}
 
 	return NextStartPoint(tw, uniCurTime) + 1*time.Minute


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6948

Trying this time window at 3:13PM on Tuesday.

```
  timewindow:
    daysofweek:
    - Monday
    - Tuesday
    - Thursday
    - Friday
    hours:
    - end: 03:16PM
      start: 03:14PM
    location: America/Toronto
    windowtype: active
```

The subscription message goes to `Active` after 3:14PM but it does not become `Blocked` after 3:!6PM.
