### PR TITLE
Channel.spec.insecureSkipVerify for helmrelease

### DIFF
--- a/examples/e2e_example/helm_channel_e2e.yaml
+++ b/examples/e2e_example/helm_channel_e2e.yaml
@@ -23,16 +23,6 @@ spec:
     matchLabels:
       name: helm-sub
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: skip-cert-verify
-  namespace: ch-helm
-  labels:
-    name: helm-sub
-data:
-  insecureSkipVerify: "true"
----
 apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
@@ -43,10 +33,7 @@ metadata:
 spec:
   type: HelmRepo
   pathname: https://ianzhang366.github.io/guestbook-chart/
-  configMapRef: 
-    name: skip-cert-verify
-    apiVersion: v1
-    kind: ConfigMap
+  insecureSkipVerify: true
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/examples/e2e_example/local_deployalbe_e2e.yaml
+++ b/examples/e2e_example/local_deployalbe_e2e.yaml
@@ -18,14 +18,6 @@ spec:
     matchLabels:
       name: helm-sub-local
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: skip-cert-verify
-  namespace: helm-local
-data:
-  insecureSkipVerify: "true"
----
 apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
@@ -36,10 +28,7 @@ metadata:
 spec:
   type: HelmRepo
   pathname: https://ianzhang366.github.io/guestbook-chart/
-  configMapRef: 
-    name: skip-cert-verify
-    apiVersion: v1
-    kind: ConfigMap
+  insecureSkipVerify: true
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription

--- a/examples/helmrepo-channel/01-channel.yaml
+++ b/examples/helmrepo-channel/01-channel.yaml
@@ -6,15 +6,4 @@ metadata:
 spec:
     type: HelmRepo
     pathname: http://kubernetes-charts.storage.googleapis.com/
-    configMapRef: 
-      name: skip-cert-verify
-      apiVersion: v1
-      kind: ConfigMap
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: skip-cert-verify
-  namespace: dev
-data:
-  insecureSkipVerify: "true"
+    insecureSkipVerify: true

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20201103204539-9d9004e1f5e6
 	github.com/open-cluster-management/multicloud-operators-deployable v0.0.0-20200817152717-50b364f569c6
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-2020-06-08-14-28-27.0.20200817152733-689893a33a7f
-	github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201106174543-f710c1acbb23
+	github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201109222655-d7e79a56b37b
 	github.com/operator-framework/operator-sdk v0.18.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -909,6 +909,8 @@ github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-202
 github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-2020-06-08-14-28-27.0.20200817152733-689893a33a7f/go.mod h1:A3sMwp+AWM4QQg/ka8gIQ+SpLG2LZXtTZA/MYdrpWVI=
 github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201106174543-f710c1acbb23 h1:7itmppdEZhsFpbI4DXvUk5/ZnFdTqLQADbP3SUDoGg8=
 github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201106174543-f710c1acbb23/go.mod h1:1qj02jDo5gXdLwWK4T5WAZskZoOVTn47cXXNX+W0UWU=
+github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201109222655-d7e79a56b37b h1:nK0t/nCMujZ7qYErwsOsS8Sk4XZF4FAryb/6gVF8KGY=
+github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201109222655-d7e79a56b37b/go.mod h1:1qj02jDo5gXdLwWK4T5WAZskZoOVTn47cXXNX+W0UWU=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=

--- a/pkg/controller/mcmhub/mcmhub_controller_test.go
+++ b/pkg/controller/mcmhub/mcmhub_controller_test.go
@@ -58,21 +58,6 @@ var (
 		Namespace: "ch-helm-ns",
 	}
 
-	cfgMapKey = types.NamespacedName{
-		Name:      "skip-cert-verify",
-		Namespace: helmKey.Namespace,
-	}
-
-	cfgMap = &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfgMapKey.Name,
-			Namespace: cfgMapKey.Namespace,
-		},
-		Data: map[string]string{
-			"insecureSkipVerify": "true",
-		},
-	}
-
 	chHelm = &chnv1alpha1.Channel{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps.open-cluster-management.io/v1",
@@ -83,14 +68,9 @@ var (
 			Namespace: helmKey.Namespace,
 		},
 		Spec: chnv1alpha1.ChannelSpec{
-			Type:     chnv1alpha1.ChannelTypeHelmRepo,
-			Pathname: "https://kubernetes-charts.storage.googleapis.com",
-			ConfigMapRef: &corev1.ObjectReference{
-				Name:       cfgMap.Name,
-				Namespace:  cfgMap.Namespace,
-				Kind:       "ConfigMap",
-				APIVersion: "v1",
-			},
+			Type:               chnv1alpha1.ChannelTypeHelmRepo,
+			Pathname:           "https://kubernetes-charts.storage.googleapis.com",
+			InsecureSkipVerify: true,
 		},
 	}
 )

--- a/pkg/controller/mcmhub/metaupdate_test.go
+++ b/pkg/controller/mcmhub/metaupdate_test.go
@@ -52,12 +52,6 @@ func TestTopoAnnotationUpdateHelm(t *testing.T) {
 
 	g.Expect(mgr.GetCache().WaitForCacheSync(stopMgr)).Should(gomega.BeTrue())
 
-	g.Expect(c.Create(context.TODO(), cfgMap)).Should(gomega.Succeed())
-
-	defer func() {
-		g.Expect(c.Delete(context.TODO(), cfgMap)).Should(gomega.Succeed())
-	}()
-
 	rec := newReconciler(mgr).(*ReconcileSubscription)
 
 	chn := chHelm.DeepCopy()
@@ -428,12 +422,9 @@ func TestTopoAnnotationUpdateHelmChannel(t *testing.T) {
 				Namespace: tpChnKey.Namespace,
 			},
 			Spec: chnv1.ChannelSpec{
-				Type:     chnv1.ChannelTypeHelmRepo,
-				Pathname: "https://ianzhang366.github.io/guestbook-chart/",
-				ConfigMapRef: &corev1.ObjectReference{
-					Name:      cfgMapKey.Name,
-					Namespace: cfgMapKey.Namespace,
-				},
+				Type:               chnv1.ChannelTypeHelmRepo,
+				Pathname:           "https://ianzhang366.github.io/guestbook-chart/",
+				InsecureSkipVerify: true,
 			},
 		}
 	)

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -159,11 +159,12 @@ func CreateOrUpdateHelmChart(
 					}},
 				},
 				Repo: releasev1.HelmReleaseRepo{
-					Source:       source,
-					ConfigMapRef: channel.Spec.ConfigMapRef,
-					SecretRef:    channel.Spec.SecretRef,
-					ChartName:    packageName,
-					Version:      chartVersions[0].GetVersion(),
+					Source:             source,
+					ConfigMapRef:       channel.Spec.ConfigMapRef,
+					InsecureSkipVerify: channel.Spec.InsecureSkipVerify,
+					SecretRef:          channel.Spec.SecretRef,
+					ChartName:          packageName,
+					Version:            chartVersions[0].GetVersion(),
 				},
 			}
 		} else {
@@ -176,11 +177,12 @@ func CreateOrUpdateHelmChart(
 		helmRelease.Kind = "HelmRelease"
 		klog.V(2).Infof("Update helmRelease repo %s", helmRelease.Name)
 		helmRelease.Repo = releasev1.HelmReleaseRepo{
-			Source:       source,
-			ConfigMapRef: channel.Spec.ConfigMapRef,
-			SecretRef:    channel.Spec.SecretRef,
-			ChartName:    packageName,
-			Version:      chartVersions[0].GetVersion(),
+			Source:             source,
+			ConfigMapRef:       channel.Spec.ConfigMapRef,
+			InsecureSkipVerify: channel.Spec.InsecureSkipVerify,
+			SecretRef:          channel.Spec.SecretRef,
+			ChartName:          packageName,
+			Version:            chartVersions[0].GetVersion(),
 		}
 	}
 


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6860

When a channel connects to a Helm repo server that is secured by a self-signed or custom TLS certificate, we need to reference a config map in a channel to skip the cert verification like below to avoid getting x509: certificate error.

```
apiVersion: apps.open-cluster-management.io/v1
kind: Channel
metadata:
  name: dev-helmrepo
  namespace: dev
spec:
    type: HelmRepo
    pathname: http://kubernetes-charts.storage.googleapis.com/
    configMapRef: 
      name: skip-cert-verify
      apiVersion: v1
      kind: ConfigMap
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: skip-cert-verify
  namespace: dev
data:
  insecureSkipVerify: "true"
```

In 2.2, this is supported but not recommended. The new way is to use `spec.insecureSkipVerify` in the channel.

```
apiVersion: apps.open-cluster-management.io/v1
kind: Channel
metadata:
  name: dev-helmrepo
  namespace: dev
spec:
    type: HelmRepo
    pathname: http://kubernetes-charts.storage.googleapis.com/
    insecureSkipVerify: true
```