### PR TITLE
Nested subscriptions should inherit cluster-admin annotation

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -228,7 +228,10 @@ func ifUpdateAnnotation(origanno, newanno map[string]string, annoString string) 
 // AddClusterAdminAnnotation adds cluster-admin annotation if conditions are met
 func (r *ReconcileSubscription) AddClusterAdminAnnotation(sub *appv1.Subscription) bool {
 	annotations := sub.GetAnnotations()
-	delete(annotations, appv1.AnnotationClusterAdmin) // make sure cluster-admin annotation is removed to begin with
+	if annotations[appv1.AnnotationHosting] == "" {
+		// if there is hosting subscription, the cluster admin annotation must have been inherited. Don't remove.
+		delete(annotations, appv1.AnnotationClusterAdmin) // make sure cluster-admin annotation is removed to begin with
+	}
 
 	if utils.IsClusterAdmin(r.Client, sub, r.eventRecorder) {
 		annotations[appv1.AnnotationClusterAdmin] = "true"

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -381,6 +381,19 @@ func (ghsi *SubscriberItem) subscribeResource(file []byte) (*dplv1.Deployable, *
 				klog.Info("Setting it to subscription namespace " + ghsi.Subscription.Namespace)
 				rsc.SetNamespace(ghsi.Subscription.Namespace)
 			}
+
+			rscAnnotations := rsc.GetAnnotations()
+
+			if rscAnnotations == nil {
+				rscAnnotations = make(map[string]string)
+			}
+
+			if strings.EqualFold(rsc.GroupVersionKind().Group, "apps.open-cluster-management.io") &&
+				strings.EqualFold(rsc.GroupVersionKind().Kind, "Subscription") {
+				// Adding cluster-admin=true annotation to child subscription
+				rscAnnotations[appv1.AnnotationClusterAdmin] = "true"
+				rsc.SetAnnotations(rscAnnotations)
+			}
 		} else {
 			klog.Info("No cluster-admin. Setting it to subscription namespace " + ghsi.Subscription.Namespace)
 			rsc.SetNamespace(ghsi.Subscription.Namespace)

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -159,6 +159,11 @@ func (sync *KubeSynchronizer) createNewResourceByTemplateUnit(ri dynamic.Resourc
 			nsanno[appv1alpha1.AnnotationSyncSource] = "subnsdpl-" + tplanno[appv1alpha1.AnnotationHosting]
 		}
 
+		if tplanno[appv1alpha1.AnnotationClusterAdmin] > "" {
+			// Do this so that nested children subscriptions inherit the cluster-admin role elevation as well.
+			nsanno[appv1alpha1.AnnotationClusterAdmin] = tplanno[appv1alpha1.AnnotationClusterAdmin]
+		}
+
 		ns.SetAnnotations(nsanno)
 
 		klog.V(1).Infof("Apply - Creating New Namespace: %#v", ns)


### PR DESCRIPTION
In nested subscriptions, children subscriptions should inherit `cluster-admin:true` annotation from the top subscription because the children subscriptions are created by subscription controllers which is not running as a subscription admin user. 

https://github.com/open-cluster-management/backlog/issues/7171