### PR TITLE
remove deprecrate manager handler creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-2020-06-08-14-28-27.0.20201118195339-05a8c4c89c12
 	github.com/open-cluster-management/multicloud-operators-subscription-release v1.0.1-2020-06-08-14-28-27.0.20201120152906-e64e01280049
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/common v0.10.0
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20200822124328-c89045814202


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The old manager handler `manager.New` needs to be removed. Or the manager handler creation `ctrl.NewManager` will be failed in hub subscription mode with the following error
```
E1124 22:28:56.500632       1 manager.go:134] error listening on 0.0.0.0:8381: listen tcp 0.0.0.0:8381: bind: address already in use
```