### PR TITLE
set up new leader election id for managed cluster mode

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -59,10 +59,15 @@ func RunManager() {
 		klog.Info("LeaderElection disabled as not running in a cluster")
 	}
 
+	// for hub subcription pod
 	leaderElectionID := "multicloud-operators-hub-subscription-leader.open-cluster-management.io"
 
 	if Options.Standalone {
+		// for standalone subcription pod
 		leaderElectionID = "multicloud-operators-standalone-subscription-leader.open-cluster-management.io"
+	} else if !strings.EqualFold(Options.ClusterName, "") && !strings.EqualFold(Options.ClusterNamespace, "") {
+		// for managed cluster pod appmgr. It could run on hub if hub is self-managed cluster
+		leaderElectionID = "multicloud-operators-remote-subscription-leader.open-cluster-management.io"
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The fix is to set up a new leaderElectionID for app sub managed cluster mode. When hub cluster is self managed cluster, there will be 3 subscriptions pods running on the hub cluster. In this case  different leaderElectionIDs should be assigned. Or we will see the app sub managed cluster pod (klusterlet-addon-appmgr) is stuck with this error message.

```
I1201 22:30:19.584755       1 leaderelection.go:243] attempting to acquire leader lease  kube-system/multicloud-operators-hub-subscription-leader.open-cluster-management.io...
```