### PR TITLE
make sure standalone and hub po is using different metrics port

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -65,6 +65,7 @@ func RunManager() {
 	if Options.Standalone {
 		// for standalone subcription pod
 		leaderElectionID = "multicloud-operators-standalone-subscription-leader.open-cluster-management.io"
+		metricsPort = "8389"
 	} else if !strings.EqualFold(Options.ClusterName, "") && !strings.EqualFold(Options.ClusterNamespace, "") {
 		// for managed cluster pod appmgr. It could run on hub if hub is self-managed cluster
 		leaderElectionID = "multicloud-operators-remote-subscription-leader.open-cluster-management.io"

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -68,6 +68,7 @@ func RunManager() {
 		metricsPort = 8389
 	} else if !strings.EqualFold(Options.ClusterName, "") && !strings.EqualFold(Options.ClusterNamespace, "") {
 		// for managed cluster pod appmgr. It could run on hub if hub is self-managed cluster
+		metricsPort = 8388
 		leaderElectionID = "multicloud-operators-remote-subscription-leader.open-cluster-management.io"
 	}
 

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -65,7 +65,7 @@ func RunManager() {
 	if Options.Standalone {
 		// for standalone subcription pod
 		leaderElectionID = "multicloud-operators-standalone-subscription-leader.open-cluster-management.io"
-		metricsPort = "8389"
+		metricsPort = 8389
 	} else if !strings.EqualFold(Options.ClusterName, "") && !strings.EqualFold(Options.ClusterNamespace, "") {
 		// for managed cluster pod appmgr. It could run on hub if hub is self-managed cluster
 		leaderElectionID = "multicloud-operators-remote-subscription-leader.open-cluster-management.io"


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Addressing issue:
https://github.com/open-cluster-management/backlog/issues/7541

I figured out the issue is caused by the crashing hub pod.

At the hub pod, we are binding metric to 0.0.0.0:8381, which is also used
by the standalone pod... This would mean is the cluster namespace, their,
IP:port could resolve to the same thing... so the hub pod can't start up
```
> oc logs multicluster-operators-hub-subscription-7b56cddfcb-shzt5
I1204 15:09:21.713837       1 request.go:645] Throttling request took 1.04007934s, request: GET:https://172.30.0.1:443/apis/flowcontrol.apiserver.k8s.io/v1alpha1?timeout=32s
I1204 15:09:24.623451       1 manager.go:93] Starting ... Registering Components for cluster: /
I1204 15:09:24.626756       1 manager.go:117] LeaderElection enabled as running in a cluster
E1204 15:09:28.589497       1 manager.go:134] error listening on 0.0.0.0:8381: listen tcp 0.0.0.0:8381: bind: address already in use
```