### PR TITLE
Support custom Git server cert

### DIFF
--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -89,6 +89,8 @@ const (
 	ReplaceReconcile = "replace"
 	// SubscriptionNameSuffix is appended to the subscription name when propagated to managed clusters
 	SubscriptionNameSuffix = ""
+	// ChannelCertificateData is the configmap data spec field containing trust certificates
+	ChannelCertificateData = "caCerts"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/pkg/controller/mcmhub/hook_suite_test.go
+++ b/pkg/controller/mcmhub/hook_suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func(done Done) {
 		return defaultCommit, nil
 	}
 
-	cloneFunc := func(string, string, string, string, string, bool) (string, error) {
+	cloneFunc := func(string, string, string, string, string, bool, string) (string, error) {
 		return defaultCommit, nil
 	}
 

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -319,9 +319,10 @@ func (h *HubGitOps) ResolveLocalGitFolder(chn *chnv1.Channel, subIns *subv1.Subs
 func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) {
 	subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
 
-	if _, ok := h.subRecords[subKey]; ok {
-		return
-	}
+	// This does not pick up new changes to channel configuration
+	//if _, ok := h.subRecords[subKey]; ok {
+	//	return
+	//}
 
 	channel, err := GetSubscriptionRefChannel(h.clt, subIns)
 

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -214,7 +214,13 @@ func (h *HubGitOps) GitWatch() {
 			h.repoRecords[repoName].branchs[bName].lastCommitID = nCommit
 			h.logger.Info("The repo has new commit: " + nCommit)
 
-			if _, err := h.cloneFunc(url, bName, branchInfo.username, branchInfo.secret, branchInfo.localDir, branchInfo.insecureSkipVerify, branchInfo.gitCACert); err != nil {
+			if _, err := h.cloneFunc(url,
+				bName,
+				branchInfo.username,
+				branchInfo.secret,
+				branchInfo.localDir,
+				branchInfo.insecureSkipVerify,
+				branchInfo.gitCACert); err != nil {
 				h.logger.Error(err, "failed to download repo for %s, at brnach @%s", repoName, bName)
 			}
 

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -345,7 +345,10 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) {
 	caCert := ""
 
 	if channelConfig != nil {
-		caCert = channelConfig.Data["ca.crt"]
+		caCert = channelConfig.Data[subv1.ChannelCertificateData]
+		if caCert != "" {
+			h.logger.Info("Channel config map with CA certs found")
+		}
 	}
 
 	skipCertVerify := false

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -562,7 +562,7 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 	caCert := ""
 
 	if ghsi.SubscriberItem.ChannelConfigMap != nil {
-		caCert = ghsi.SubscriberItem.ChannelConfigMap.Data["ca.crt"]
+		caCert = ghsi.SubscriberItem.ChannelConfigMap.Data[appv1.ChannelCertificateData]
 	}
 
 	return utils.CloneGitRepo(

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -559,13 +559,20 @@ func (ghsi *SubscriberItem) cloneGitRepo() (commitID string, err error) {
 		}
 	}
 
+	caCert := ""
+
+	if ghsi.SubscriberItem.ChannelConfigMap != nil {
+		caCert = ghsi.SubscriberItem.ChannelConfigMap.Data["ca.crt"]
+	}
+
 	return utils.CloneGitRepo(
 		ghsi.Channel.Spec.Pathname,
 		utils.GetSubscriptionBranch(ghsi.Subscription),
 		user,
 		token,
 		ghsi.repoRoot,
-		ghsi.Channel.Spec.InsecureSkipVerify)
+		ghsi.Channel.Spec.InsecureSkipVerify,
+		caCert)
 }
 
 func (ghsi *SubscriberItem) sortClonedGitRepo() error {

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -115,9 +115,11 @@ func getCertChain(certs string) tls.Certificate {
 
 	for {
 		certDERBlock, certPEMBlock = pem.Decode(certPEMBlock)
+
 		if certDERBlock == nil {
 			break
 		}
+
 		if certDERBlock.Type == "CERTIFICATE" {
 			certChain.Certificate = append(certChain.Certificate, certDERBlock.Bytes)
 		}

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -147,7 +147,7 @@ func CloneGitRepo(
 			certPool = x509.NewCertPool()
 		}
 
-		// Append our cert to the system pool
+		// Append the Git root/intermediate CA cert to the system pool
 		if ok := certPool.AppendCertsFromPEM([]byte(caCert)); !ok {
 			klog.Error("Failed to add Git server's CA certificate to trust certificate pool")
 		}

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -108,8 +108,11 @@ func KubeResourceParser(file []byte, cond Kube) [][]byte {
 
 func getCertChain(certs string) tls.Certificate {
 	var certChain tls.Certificate
+
 	certPEMBlock := []byte(certs)
+
 	var certDERBlock *pem.Block
+
 	for {
 		certDERBlock, certPEMBlock = pem.Decode(certPEMBlock)
 		if certDERBlock == nil {
@@ -119,6 +122,7 @@ func getCertChain(certs string) tls.Certificate {
 			certChain.Certificate = append(certChain.Certificate, certDERBlock.Bytes)
 		}
 	}
+
 	return certChain
 }
 
@@ -296,11 +300,12 @@ func GetChannelSecret(client client.Client, chn *chnv1.Channel) (string, string,
 // GetDataFromChannelConfigMap returns username and password for channel
 func GetChannelConfigMap(client client.Client, chn *chnv1.Channel) *corev1.ConfigMap {
 	if chn.Spec.ConfigMapRef != nil {
-		klog.Info("ROKEROKE There is configmap " + chn.Spec.ConfigMapRef.Name)
 		configMapRet := &corev1.ConfigMap{}
+
 		cmns := chn.Namespace
 
 		err := client.Get(context.TODO(), types.NamespacedName{Name: chn.Spec.ConfigMapRef.Name, Namespace: cmns}, configMapRet)
+
 		if err != nil {
 			klog.Error(err, "Unable to get config map from local cluster.")
 			return nil

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -129,14 +129,13 @@ func CloneGitRepo(
 
 	installProtocol := false
 
-	clientConfig := &tls.Config{}
+	clientConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	// skip TLS certificate verification for Git servers with custom or self-signed certs
 	if insecureSkipVerify {
 		klog.Info("insecureSkipVerify = true, skipping Git server's certificate verification.")
 
 		clientConfig.InsecureSkipVerify = true
-		clientConfig.MinVersion = tls.VersionTLS12
 
 		installProtocol = true
 	} else if !strings.EqualFold(caCert, "") {
@@ -153,7 +152,6 @@ func CloneGitRepo(
 		}
 
 		clientConfig.RootCAs = certPool
-		clientConfig.MinVersion = tls.VersionTLS12
 
 		installProtocol = true
 	}

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -164,6 +164,7 @@ func CloneGitRepo(
 	} else if !strings.EqualFold(caCerts, "") {
 		klog.Info("Adding Git server's CA certificate to trust certificate pool")
 
+		// Load the host's trusted certs into memory
 		certPool, _ := x509.SystemCertPool()
 		if certPool == nil {
 			certPool = x509.NewCertPool()
@@ -175,12 +176,14 @@ func CloneGitRepo(
 			klog.Warning("No certificate found")
 		}
 
+		// Add CA certs from the channel config map to the cert pool
+		// It will not add duplicate certs
 		for _, cert := range certChain.Certificate {
 			x509Cert, err := x509.ParseCertificate(cert)
 			if err != nil {
 				panic(err)
 			}
-			fmt.Println("Adding certificate -->" + x509Cert.Subject.String())
+			klog.Info("Adding certificate -->" + x509Cert.Subject.String())
 			certPool.AddCert(x509Cert)
 		}
 
@@ -464,7 +467,7 @@ func sortKubeResource(crdsAndNamespaceFiles, rbacFiles, otherFiles []string, pat
 			err := yaml.Unmarshal(resources[0], &t)
 
 			if err != nil {
-				fmt.Println("Failed to unmarshal YAML file")
+				klog.Warning("Failed to unmarshal YAML file")
 				// Just ignore the YAML
 				return crdsAndNamespaceFiles, rbacFiles, otherFiles, nil
 			}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7529

This supports subscribing to an application from a Git server with custom SSL certificate. 

1. Create a config map to contain the Git server's root and intermediate CA certificates in PEM format. The config map must be in the same namespace as the channel CR and should look like this. `data.ca.crt` is required.

```
apiVersion: v1
data:
  caCerts: |
    # Git server root CA

    -----BEGIN CERTIFICATE-----
    MIIF5DCCA8wCCQDInYMol7LSDTANBgkqhkiG9w0BAQsFADCBszELMAkGA1UEBhMC
    Q0ExCzAJBgNVBAgMAk9OMRAwDgYDVQQHDAdUb3JvbnRvMQ8wDQYDVQQKDAZSZWRI
    YXQxDDAKBgNVBAsMA0FDTTFFMEMGA1UEAww8Z29ncy1zdmMtZGVmYXVsdC5hcHBz
    LnJqdW5nLWh1YjEzLmRldjA2LnJlZC1jaGVzdGVyZmllbGQuY29tMR8wHQYJKoZI
    hvcNAQkBFhByb2tlakByZWRoYXQuY29tMB4XDTIwMTIwMzE4NTMxMloXDTIzMDky
    MzE4NTMxMlowgbMxCzAJBgNVBAYTAkNBMQswCQYDVQQIDAJPTjEQMA4GA1UEBwwH
    VG9yb250bzEPMA0GA1UECgwGUmVkSGF0MQwwCgYDVQQLDANBQ00xRTBDBgNVBAMM
    PGdvZ3Mtc3ZjLWRlZmF1bHQuYXBwcy5yanVuZy1odWIxMy5kZXYwNi5yZWQtY2hl
    c3RlcmZpZWxkLmNvbTEfMB0GCSqGSIb3DQEJARYQcm9rZWpAcmVkaGF0LmNvbTCC
    AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAM3nPK4mOQzaDAo6S3ZJ0Ic3
    U9p/NLodnoTIC+cn0q8qNCAjf13zbGB3bfN9Zxl8Q5fv+wYwHrUOReCp6U/InyQy
    6OS3gj738F635inz1KdyhKtlWW2p9Ye9DUtx1IlfHkDVdXtynjHQbsFNIdRHcpQP
    upM5pwPC3BZXqvXChhlfAy2m4yu7vy0hO/oTzWIwNsoL5xt0Lw4mSyhlEip/t8lU
    xn2y8qhm7MiIUpXuwWhSYgCrEVqmTcB70Pc2YRZdSFolMN9Et70MjQN0TXjoktH8
    PyASJIKIRd+48yROIbUn8rj4aYYBsJuoSCjJNwujZPbqseqUr42+v+Qp2bBj1Sjw
    +SEZfHTvSv8AqX0T6eo6njr578+DgYlwsS1A1zcAdzp8qmDGqvJDzwcnQVFmvaoM
    gGHCdJihfy3vDhxuZRDse0V4Pz6tl6iklM+tHrJL/bdL0NdfJXNCqn2nKrM51fpw
    diNXs4Zn3QSStC2x2hKnK+Q1rwCSEg/lBawgxGUslTboFH77a+Kwu4Oug9ibtm5z
    ISs/JY4Kiy4C2XJOltOR2XZYkdKaX4x3ctbrGaD8Bj+QHiSAxaaSXIX+VbzkHF2N
    aD5ijFUopjQEKFrYh3O93DB/URIQ+wHVa6+Kvu3uqE0cg6pQsLpbFVQ/I8xHvt9L
    kYy6z6V/nj9ZYKQbq/kPAgMBAAEwDQYJKoZIhvcNAQELBQADggIBAKZuc+lewYAv
    jaaSeRDRoToTb/yN0Xsi69UfK0aBdvhCa7/0rPHcv8hmUBH3YgkZ+CSA5ygajtL4
    g2E8CwIO9ZjZ6l+pHCuqmNYoX1wdjaaDXlpwk8hGTSgy1LsOoYrC5ZysCi9Jilu9
    PQVGs/vehQRqLV9uZBigG6oZqdUqEimaLHrOcEAHB5RVcnFurz0qNbT+UySjsD63
    9yJdCeQbeKAR9SC4hG13EbM/RZh0lgFupkmGts7QYULzT+oA0cCJpPLQl6m6qGyE
    kh9aBB7FLykK1TeXVuANlNU4EMyJ/e+uhNkS9ubNJ3vuRuo+ECHsha058yi16JC9
    NkZqP+df4Hp85sd+xhrgYieq7QGX2KOXAjqAWo9htoBhOyW3mm783A7WcOiBMQv0
    2UGZxMsRjlP6UqB08LsV5ZBAefElR344sokJR1de/Sx2J9J/am7yOoqbtKpQotIA
    XSUkATuuQw4ctyZLDkUpzrDzgd2Bt+aawF6sD2YqycaGFwv2YD9t1YlD6F4Wh8Mc
    20Qu5EGrkQTCWZ9pOHNSa7YQdmJzwbxJC4hqBpBRAJFI2fAIqFtyum6/8ZN9nZ9K
    FSEKdlu+xeb6Y6xYt0mJJWF6mCRi4i7IL74EU/VNXwFmfP6IadliUOST3w5t92cB
    M26t73UCExXMXTCQvnp0ki84PeR1kRk4
    -----END CERTIFICATE-----

    # Git server intermediate CA 1

    -----BEGIN CERTIFICATE-----
    MIIF5DCCA8wCCQDInYMol7LSDTANBgkqhkiG9w0BAQsFADCBszELMAkGA1UEBhMC
    Q0ExCzAJBgNVBAgMAk9OMRAwDgYDVQQHDAdUb3JvbnRvMQ8wDQYDVQQKDAZSZWRI
    YXQxDDAKBgNVBAsMA0FDTTFFMEMGA1UEAww8Z29ncy1zdmMtZGVmYXVsdC5hcHBz
    LnJqdW5nLWh1YjEzLmRldjA2LnJlZC1jaGVzdGVyZmllbGQuY29tMR8wHQYJKoZI
    hvcNAQkBFhByb2tlakByZWRoYXQuY29tMB4XDTIwMTIwMzE4NTMxMloXDTIzMDky
    MzE4NTMxMlowgbMxCzAJBgNVBAYTAkNBMQswCQYDVQQIDAJPTjEQMA4GA1UEBwwH
    VG9yb250bzEPMA0GA1UECgwGUmVkSGF0MQwwCgYDVQQLDANBQ00xRTBDBgNVBAMM
    PGdvZ3Mtc3ZjLWRlZmF1bHQuYXBwcy5yanVuZy1odWIxMy5kZXYwNi5yZWQtY2hl
    c3RlcmZpZWxkLmNvbTEfMB0GCSqGSIb3DQEJARYQcm9rZWpAcmVkaGF0LmNvbTCC
    AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAM3nPK4mOQzaDAo6S3ZJ0Ic3
    U9p/NLodnoTIC+cn0q8qNCAjf13zbGB3bfN9Zxl8Q5fv+wYwHrUOReCp6U/InyQy
    6OS3gj738F635inz1KdyhKtlWW2p9Ye9DUtx1IlfHkDVdXtynjHQbsFNIdRHcpQP
    upM5pwPC3BZXqvXChhlfAy2m4yu7vy0hO/oTzWIwNsoL5xt0Lw4mSyhlEip/t8lU
    xn2y8qhm7MiIUpXuwWhSYgCrEVqmTcB70Pc2YRZdSFolMN9Et70MjQN0TXjoktH8
    PyASJIKIRd+48yROIbUn8rj4aYYBsJuoSCjJNwujZPbqseqUr42+v+Qp2bBj1Sjw
    +SEZfHTvSv8AqX0T6eo6njr578+DgYlwsS1A1zcAdzp8qmDGqvJDzwcnQVFmvaoM
    gGHCdJihfy3vDhxuZRDse0V4Pz6tl6iklM+tHrJL/bdL0NdfJXNCqn2nKrM51fpw
    diNXs4Zn3QSStC2x2hKnK+Q1rwCSEg/lBawgxGUslTboFH77a+Kwu4Oug9ibtm5z
    ISs/JY4Kiy4C2XJOltOR2XZYkdKaX4x3ctbrGaD8Bj+QHiSAxaaSXIX+VbzkHF2N
    aD5ijFUopjQEKFrYh3O93DB/URIQ+wHVa6+Kvu3uqE0cg6pQsLpbFVQ/I8xHvt9L
    kYy6z6V/nj9ZYKQbq/kPAgMBAAEwDQYJKoZIhvcNAQELBQADggIBAKZuc+lewYAv
    jaaSeRDRoToTb/yN0Xsi69UfK0aBdvhCa7/0rPHcv8hmUBH3YgkZ+CSA5ygajtL4
    g2E8CwIO9ZjZ6l+pHCuqmNYoX1wdjaaDXlpwk8hGTSgy1LsOoYrC5ZysCi9Jilu9
    PQVGs/vehQRqLV9uZBigG6oZqdUqEimaLHrOcEAHB5RVcnFurz0qNbT+UySjsD63
    9yJdCeQbeKAR9SC4hG13EbM/RZh0lgFupkmGts7QYULzT+oA0cCJpPLQl6m6qGyE
    kh9aBB7FLykK1TeXVuANlNU4EMyJ/e+uhNkS9ubNJ3vuRuo+ECHsha058yi16JC9
    NkZqP+df4Hp85sd+xhrgYieq7QGX2KOXAjqAWo9htoBhOyW3mm783A7WcOiBMQv0
    2UGZxMsRjlP6UqB08LsV5ZBAefElR344sokJR1de/Sx2J9J/am7yOoqbtKpQotIA
    XSUkATuuQw4ctyZLDkUpzrDzgd2Bt+aawF6sD2YqycaGFwv2YD9t1YlD6F4Wh8Mc
    20Qu5EGrkQTCWZ9pOHNSa7YQdmJzwbxJC4hqBpBRAJFI2fAIqFtyum6/8ZN9nZ9K
    FSEKdlu+xeb6Y6xYt0mJJWF6mCRi4i7IL74EU/VNXwFmfP6IadliUOST3w5t92cB
    M26t73UCExXMXTCQvnp0ki84PeR1kRk4
    -----END CERTIFICATE-----

    # Git server intermediate CA 2

    -----BEGIN CERTIFICATE-----
    MIIF5DCCA8wCCQDInYMol7LSDTANBgkqhkiG9w0BAQsFADCBszELMAkGA1UEBhMC
    Q0ExCzAJBgNVBAgMAk9OMRAwDgYDVQQHDAdUb3JvbnRvMQ8wDQYDVQQKDAZSZWRI
    YXQxDDAKBgNVBAsMA0FDTTFFMEMGA1UEAww8Z29ncy1zdmMtZGVmYXVsdC5hcHBz
    LnJqdW5nLWh1YjEzLmRldjA2LnJlZC1jaGVzdGVyZmllbGQuY29tMR8wHQYJKoZI
    hvcNAQkBFhByb2tlakByZWRoYXQuY29tMB4XDTIwMTIwMzE4NTMxMloXDTIzMDky
    MzE4NTMxMlowgbMxCzAJBgNVBAYTAkNBMQswCQYDVQQIDAJPTjEQMA4GA1UEBwwH
    VG9yb250bzEPMA0GA1UECgwGUmVkSGF0MQwwCgYDVQQLDANBQ00xRTBDBgNVBAMM
    PGdvZ3Mtc3ZjLWRlZmF1bHQuYXBwcy5yanVuZy1odWIxMy5kZXYwNi5yZWQtY2hl
    c3RlcmZpZWxkLmNvbTEfMB0GCSqGSIb3DQEJARYQcm9rZWpAcmVkaGF0LmNvbTCC
    AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAM3nPK4mOQzaDAo6S3ZJ0Ic3
    U9p/NLodnoTIC+cn0q8qNCAjf13zbGB3bfN9Zxl8Q5fv+wYwHrUOReCp6U/InyQy
    6OS3gj738F635inz1KdyhKtlWW2p9Ye9DUtx1IlfHkDVdXtynjHQbsFNIdRHcpQP
    upM5pwPC3BZXqvXChhlfAy2m4yu7vy0hO/oTzWIwNsoL5xt0Lw4mSyhlEip/t8lU
    xn2y8qhm7MiIUpXuwWhSYgCrEVqmTcB70Pc2YRZdSFolMN9Et70MjQN0TXjoktH8
    PyASJIKIRd+48yROIbUn8rj4aYYBsJuoSCjJNwujZPbqseqUr42+v+Qp2bBj1Sjw
    +SEZfHTvSv8AqX0T6eo6njr578+DgYlwsS1A1zcAdzp8qmDGqvJDzwcnQVFmvaoM
    gGHCdJihfy3vDhxuZRDse0V4Pz6tl6iklM+tHrJL/bdL0NdfJXNCqn2nKrM51fpw
    diNXs4Zn3QSStC2x2hKnK+Q1rwCSEg/lBawgxGUslTboFH77a+Kwu4Oug9ibtm5z
    ISs/JY4Kiy4C2XJOltOR2XZYkdKaX4x3ctbrGaD8Bj+QHiSAxaaSXIX+VbzkHF2N
    aD5ijFUopjQEKFrYh3O93DB/URIQ+wHVa6+Kvu3uqE0cg6pQsLpbFVQ/I8xHvt9L
    kYy6z6V/nj9ZYKQbq/kPAgMBAAEwDQYJKoZIhvcNAQELBQADggIBAKZuc+lewYAv
    jaaSeRDRoToTb/yN0Xsi69UfK0aBdvhCa7/0rPHcv8hmUBH3YgkZ+CSA5ygajtL4
    g2E8CwIO9ZjZ6l+pHCuqmNYoX1wdjaaDXlpwk8hGTSgy1LsOoYrC5ZysCi9Jilu9
    PQVGs/vehQRqLV9uZBigG6oZqdUqEimaLHrOcEAHB5RVcnFurz0qNbT+UySjsD63
    9yJdCeQbeKAR9SC4hG13EbM/RZh0lgFupkmGts7QYULzT+oA0cCJpPLQl6m6qGyE
    kh9aBB7FLykK1TeXVuANlNU4EMyJ/e+uhNkS9ubNJ3vuRuo+ECHsha058yi16JC9
    NkZqP+df4Hp85sd+xhrgYieq7QGX2KOXAjqAWo9htoBhOyW3mm783A7WcOiBMQv0
    2UGZxMsRjlP6UqB08LsV5ZBAefElR344sokJR1de/Sx2J9J/am7yOoqbtKpQotIA
    XSUkATuuQw4ctyZLDkUpzrDzgd2Bt+aawF6sD2YqycaGFwv2YD9t1YlD6F4Wh8Mc
    20Qu5EGrkQTCWZ9pOHNSa7YQdmJzwbxJC4hqBpBRAJFI2fAIqFtyum6/8ZN9nZ9K
    FSEKdlu+xeb6Y6xYt0mJJWF6mCRi4i7IL74EU/VNXwFmfP6IadliUOST3w5t92cB
    M26t73UCExXMXTCQvnp0ki84PeR1kRk4
    -----END CERTIFICATE-----
kind: ConfigMap
metadata:
  name: git-ca
  namespace: channel-ns
```

If you are creating an application using the ACM UI, add this manually in application YAML edit mode.

2. Associate this config map with the channel like this.

```
apiVersion: apps.open-cluster-management.io/v1
kind: Channel
metadata:
  name: my-channel
  namespace: channel-ns
spec:
  configMapRef:
    name: git-ca
  pathname: https://my.git.server.com/test1.git
  type: Git
```

If you are creating an application using the ACM UI, add this `configMapRef` manually in application YAML edit mode.