### PR TITLE
apply Kubernetes copyright to lease controller

### DIFF
--- a/pkg/controller/mcmhub/mcmhub_controller_test.go
+++ b/pkg/controller/mcmhub/mcmhub_controller_test.go
@@ -69,7 +69,7 @@ var (
 		},
 		Spec: chnv1alpha1.ChannelSpec{
 			Type:               chnv1alpha1.ChannelTypeHelmRepo,
-			Pathname:           "https://kubernetes-charts.storage.googleapis.com",
+			Pathname:           "https://ianzhang366.github.io/guestbook-chart/",
 			InsecureSkipVerify: true,
 		},
 	}

--- a/pkg/controller/mcmhub/metaupdate_test.go
+++ b/pkg/controller/mcmhub/metaupdate_test.go
@@ -63,9 +63,9 @@ func TestTopoAnnotationUpdateHelm(t *testing.T) {
 
 	subIns := subscription.DeepCopy()
 	subIns.SetName("helm-sub")
-	subIns.Spec.Package = "nginx-ingress"
+	subIns.Spec.Package = "gbapp"
 	subIns.Spec.Channel = helmKey.String()
-	subIns.Spec.PackageFilter = &subv1.PackageFilter{Version: "1.26.0"}
+	subIns.Spec.PackageFilter = &subv1.PackageFilter{Version: "0.1.0"}
 	g.Expect(c.Create(context.TODO(), subIns)).NotTo(gomega.HaveOccurred())
 
 	defer func() {

--- a/pkg/controller/subscription/lease_controller.go
+++ b/pkg/controller/subscription/lease_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Kubernetes Authors.
+// Copyright 2020 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/subscription/lease_controller.go
+++ b/pkg/controller/subscription/lease_controller.go
@@ -1,6 +1,16 @@
-//###############################################################################
-//# Copyright (c) 2020 Red Hat, Inc.
-//###############################################################################
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package subscription
 

--- a/pkg/controller/subscription/lease_controller_test.go
+++ b/pkg/controller/subscription/lease_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Kubernetes Authors.
+// Copyright 2020 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/subscription/lease_controller_test.go
+++ b/pkg/controller/subscription/lease_controller_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package subscription
 
 import (


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

Two issues are addressed:

1. The k8s google helm chart repo https://kubernetes-charts.storage.googleapis.com. has deprecated for some reason. All helm chart urls are now showing:
```
    urls:
    - https://github.com/viglesiasce/deprecation-chart/releases/download/v0.2.2/deprecation-0.2.2.tgz
```
That caused the failure of our subscription repo test automation. 

2. copyright changes
