### PR TITLE
Add insecure SSH Git connection option

### DIFF
--- a/docs/git_server_connection_types.md
+++ b/docs/git_server_connection_types.md
@@ -191,7 +191,7 @@ metadata:
 spec:
   configMapRef:
     name: git-ca
-  pathname: https://my.git.server.com/test1.git
+  pathname: <Git URL>
   type: Git
 ```
 
@@ -222,8 +222,24 @@ metadata:
 spec:
   secretRef:
     name: git-ssh-key
-  pathname: https://my.git.server.com/test1.git
+  pathname: <Git SSH URL>
   type: Git
+```
+
+3. The subscription controller does `ssh-keyscan` with the provided Git hostname to build the known_hosts list to prevent MITM attack in SSH connection. If you want to skip this and make insecure connection, use `insecureSkipVerify: true` in the channel configuration.
+
+```
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: my-channel
+  namespace: channel-ns
+spec:
+  secretRef:
+    name: git-ssh-key
+  pathname: <Git SSH URL>
+  type: Git
+  insecureSkipVerify: true
 ```
 
 ## Updating channel secret and config map

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -263,6 +263,7 @@ func getSSHOptions(options *git.CloneOptions, sshKey, passphrase []byte, knownho
 
 	if insecureSkipVerify {
 		klog.Info("Insecure ignore SSH host key")
+
 		publicKey.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 	} else {
 		klog.Info("Using SSH known host keys")

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -264,7 +264,7 @@ func getSSHOptions(options *git.CloneOptions, sshKey, passphrase []byte, knownho
 	if insecureSkipVerify {
 		klog.Info("Insecure ignore SSH host key")
 
-		publicKey.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+		publicKey.HostKeyCallback = ssh.InsecureIgnoreHostKey() // #nosec G106 this is optional and used only if users specify it in channel configuration
 	} else {
 		klog.Info("Using SSH known host keys")
 		callback, err := knownhosts.New(knownhostsfile)


### PR DESCRIPTION
In some cases, users might want to skip SSH host key verification. Provide this connection option.