### PR TITLE
Prevent using both local and remote placement

### DIFF
--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -520,6 +520,10 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result rec
 	if pl == nil {
 		instance.Status.Phase = appv1.SubscriptionPropagationFailed
 		instance.Status.Reason = "Placement must be specified"
+	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) && (pl.Local != nil && *pl.Local) {
+		logger.Error("both local placement and remote placement rule are defined in the subscription")
+		instance.Status.Phase = appv1.SubscriptionPropagationFailed
+		instance.Status.Reason = "local placement and remote placement rule cannot be used together"
 	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) {
 		if err := r.hubGitOps.RegisterBranch(instance); err != nil {
 			logger.Error(err, "failed to initialize Git connection")

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -521,7 +521,7 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (result rec
 		instance.Status.Phase = appv1.SubscriptionPropagationFailed
 		instance.Status.Reason = "Placement must be specified"
 	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) && (pl.Local != nil && *pl.Local) {
-		logger.Error("both local placement and remote placement rule are defined in the subscription")
+		logger.Info("both local placement and remote placement rule are defined in the subscription")
 		instance.Status.Phase = appv1.SubscriptionPropagationFailed
 		instance.Status.Reason = "local placement and remote placement rule cannot be used together"
 	} else if pl != nil && (pl.PlacementRef != nil || pl.Clusters != nil || pl.ClusterSelector != nil) {

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 	annotations := instance.GetAnnotations()
 	pl := instance.Spec.Placement
 
-	if pl != nil && pl.Local != nil && *pl.Local {
+	if pl != nil && pl.Local != nil && *pl.Local && pl.PlacementRef == nil && pl.Clusters == nil && pl.ClusterSelector == nil {
 		// If standalone = true, reconcile standalone subscriptions without hosting subscription from ACM hub.
 		// If standalone = false, reconcile subscriptions that are propagated from ACM hub. These subscriptions have this annotation.
 		if (strings.EqualFold(annotations[appv1.AnnotationHosting], "") && r.standalone) ||


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7146

Prevent subscription to be reconciled when there are both local and remote placement rules.

```
  placement:
    local: true
    placementRef:
      name: dev-clusters
```