### PR TITLE
Resource level reconcile option

### DIFF
--- a/docs/gitrepo_subscription.md
+++ b/docs/gitrepo_subscription.md
@@ -252,10 +252,10 @@ In order to configure webhook in a Git repository, you need a target webhook pay
 Create a route (ingress) to expose the subscription operator's webhook event listener service where `<operator namespace>` is the namespace where the subscription operator runs in.
 
   ```shell
-  oc create route passthrough --service=multicloud-operators-subscription -n <operator namespace>
+  oc create route passthrough --service=multicluster-operators-subscription -n <operator namespace>
   ```
 
-Then, use `oc get route multicloud-operators-subscription -n <operator namespace>` command to find the externally-reachable hostname. The webhook payload URL is `https://<externally-reachable hostname>/webhook`.
+Then, use `oc get route multicluster-operators-subscription -n <operator namespace>` command to find the externally-reachable hostname. The webhook payload URL is `https://<externally-reachable hostname>/webhook`.
 
 ### WebHook secret
 

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -449,8 +449,14 @@ func (ghsi *SubscriberItem) subscribeResource(file []byte) (*dplv1.Deployable, *
 			rscAnnotations[appv1.AnnotationClusterAdmin] = "true"
 		}
 
-		if subAnnotations[appv1.AnnotationResourceReconcileOption] != "" {
-			rscAnnotations[appv1.AnnotationResourceReconcileOption] = subAnnotations[appv1.AnnotationResourceReconcileOption]
+		// If the reconcile-option is set in the resource, honor that. Otherwise, take the subscription's reconcile-option
+		if rscAnnotations[appv1.AnnotationResourceReconcileOption] == "" {
+			if subAnnotations[appv1.AnnotationResourceReconcileOption] != "" {
+				rscAnnotations[appv1.AnnotationResourceReconcileOption] = subAnnotations[appv1.AnnotationResourceReconcileOption]
+			} else {
+				// By default, merge reconcile
+				rscAnnotations[appv1.AnnotationResourceReconcileOption] = appv1.MergeReconcile
+			}
 		}
 
 		rsc.SetAnnotations(rscAnnotations)

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -286,6 +286,7 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 		if isService {
 			klog.Info("merging services or service account resource")
 		}
+
 		var objb, tplb, pb []byte
 		objb, err = obj.MarshalJSON()
 

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -283,6 +283,9 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 	}
 
 	if merge || isService {
+		if isService {
+			klog.Info("merging services or service account resource")
+		}
 		var objb, tplb, pb []byte
 		objb, err = obj.MarshalJSON()
 
@@ -345,12 +348,17 @@ var serviceGVR = schema.GroupVersionResource{
 	Resource: "services",
 }
 
+var serviceAccountGVR = schema.GroupVersionResource{
+	Version:  "v1",
+	Resource: "serviceaccounts",
+}
+
 func (sync *KubeSynchronizer) applyKindTemplates(res *ResourceMap) {
 	nri := sync.DynamicClient.Resource(res.GroupVersionResource)
 
 	for k, tplunit := range res.TemplateMap {
 		klog.V(1).Infof("k: %v, res.GroupVersionResource: %v", k, res.GroupVersionResource)
-		err := sync.applyTemplate(nri, res.Namespaced, k, tplunit, (res.GroupVersionResource == serviceGVR))
+		err := sync.applyTemplate(nri, res.Namespaced, k, tplunit, (res.GroupVersionResource == serviceGVR || res.GroupVersionResource == serviceAccountGVR))
 
 		if err != nil {
 			klog.Error("Failed to apply kind template", tplunit.Unstructured, "with error:", err)

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -940,7 +940,6 @@ func RemoveSubAnnotations(obj *unstructured.Unstructured) *unstructured.Unstruct
 		delete(objanno, appv1.AnnotationSyncSource)
 		delete(objanno, dplv1.AnnotationHosting)
 		delete(objanno, appv1.AnnotationChannelType)
-		delete(objanno, appv1.AnnotationResourceReconcileOption)
 	}
 
 	if len(objanno) > 0 {


### PR DESCRIPTION
With this PR, users can add `apps.open-cluster-management.io/reconcile-option` with value of either `replace` or `merge` in individual subscribed resource which will override subscription's reconcile-option.

Also, `serviceaccounts` kind resource should always be merge reconcile because when a serviceaccount is initially created, it generates secrets and updates the service account with these. Replace reconciling this resource causes secrets to be generated on every reconcile.