### PR TITLE
3-way merge patch is not working if a spec field such as timeWindow i…

### DIFF
--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -292,14 +292,6 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 	if merge || isService {
 		if isService {
 			klog.Info("merging services or service account resource")
-
-			if strings.EqualFold(tplunit.GetKind(), "service") &&
-				strings.EqualFold(tplunit.GetAPIVersion(), "v1") {
-				// delete original spec.clusterIP from the service object before merge patch as clusterIP is auto-generated and immutable
-				unstructured.RemoveNestedField(obj.Object, "spec", "clusterIP")
-
-				klog.Infof("new service obj: %#v", obj.Object)
-			}
 		}
 
 		var objb, tplb, pb []byte

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -285,6 +285,11 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 	if merge || isService {
 		if isService {
 			klog.Info("merging services or service account resource")
+
+			// delete original spec.clusterIP from the service object before merge patch as clusterIP is auto-generated and immutable
+			unstructured.RemoveNestedField(obj.Object, "spec", "clusterIP")
+
+			klog.Infof("new service obj: %#v", obj.Object)
 		}
 
 		var objb, tplb, pb []byte
@@ -302,7 +307,7 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 			return err
 		}
 
-		pb, err = jsonpatch.CreateThreeWayJSONMergePatch(tplb, tplb, objb)
+		pb, err = jsonpatch.CreateThreeWayJSONMergePatch(objb, tplb, objb)
 		if err != nil {
 			klog.Error("Failed to make patch with error:", err)
 			return err

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -292,6 +292,14 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 	if merge || isService {
 		if isService {
 			klog.Info("merging services or service account resource")
+
+			if strings.EqualFold(tplunit.GetKind(), "service") &&
+				strings.EqualFold(tplunit.GetAPIVersion(), "v1") {
+				// delete original spec.clusterIP from the service object before merge patch as clusterIP is auto-generated and immutable
+				unstructured.RemoveNestedField(obj.Object, "spec", "clusterIP")
+
+				klog.Infof("new service obj: %#v", obj.Object)
+			}
 		}
 
 		var objb, tplb, pb []byte

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -269,6 +269,13 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 		merge = false
 	}
 
+	if strings.EqualFold(tplunit.GetKind(), "subscription") &&
+		strings.EqualFold(tplunit.GetAPIVersion(), "apps.open-cluster-management.io/v1") {
+		klog.Info("Always apply replace to appsub kind resource")
+
+		merge = false
+	}
+
 	newobj := tplunit.Unstructured.DeepCopy()
 	newobj.SetResourceVersion(obj.GetResourceVersion())
 
@@ -285,11 +292,6 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 	if merge || isService {
 		if isService {
 			klog.Info("merging services or service account resource")
-
-			// delete original spec.clusterIP from the service object before merge patch as clusterIP is auto-generated and immutable
-			unstructured.RemoveNestedField(obj.Object, "spec", "clusterIP")
-
-			klog.Infof("new service obj: %#v", obj.Object)
 		}
 
 		var objb, tplb, pb []byte
@@ -307,7 +309,9 @@ func (sync *KubeSynchronizer) updateResourceByTemplateUnit(ri dynamic.ResourceIn
 			return err
 		}
 
-		pb, err = jsonpatch.CreateThreeWayJSONMergePatch(objb, tplb, objb)
+		// Note: this 3-way merge patch doesn't work on deletion patch, we don't support delete patch yet.
+		// replace is recommended for deleting fields
+		pb, err = jsonpatch.CreateThreeWayJSONMergePatch(tplb, tplb, objb)
 		if err != nil {
 			klog.Error("Failed to make patch with error:", err)
 			return err


### PR DESCRIPTION
…s removed

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/open-cluster-management/backlog/issues/8975

1.  when app time window is set to "always active", the `spec.timeWindow` is field is removed.  The deletion patch is not added.
2.  patch service resource failed due to immutable field  `clusterIP`