### PR TITLE
to fix unknown flag error in multi-cluster-operators-application pod

### DIFF
--- a/deploy/hub/application-operator.yaml
+++ b/deploy/hub/application-operator.yaml
@@ -118,7 +118,6 @@ spec:
       - command:
         - /usr/local/bin/multicluster-operators-channel
         - --alsologtostderr
-        - --debug=true
         env:
         - name: WATCH_NAMESPACE
         - name: POD_NAME


### PR DESCRIPTION
Hi folks, testing the [application management in open-cluster-management website]
(https://open-cluster-management.io/getting-started/install-application/) I found this small issue. It seems that the multicluster-operators-channel image doesn't have the --debug flag.

Here is the logs
kubectl --context=kind-hub logs -p multicluster-operators-application-84bc4f858f-5dt9k -c multicluster-operators-channel -n multicluster-operators  
unknown flag: --debug
unknown flag: --debug
Usage of /usr/local/bin/multicluster-operators-channel:
      --kubeconfig string                Paths to a kubeconfig. Only required if out-of-cluster.
      --logtostderr                      log to standard error instead of files (default true)
      --master --kubeconfig              (Deprecated: switch to --kubeconfig) The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
      --metrics-addr string              The address the metric endpoint binds to.
      --sync-interval int                Setting up the cache sync time. (default 60)
  -v, --v Level                          number for the log level verbosity
      --zap-devel                        Enable zap development mode (changes defaults to console encoder, debug log level, disables sampling and stacktrace from 'warning' level)
      --zap-encoder encoder              Zap log encoding ('json' or 'console')
      --zap-level level                  Zap log level (one of 'debug', 'info', 'error' or any integer value > 0) (default info)
      --zap-sample sample                Enable zap log sampling. Sampling will be disabled for integer log levels > 1
      --zap-stacktrace-level level       Set the minimum log level that triggers stacktrace generation (default error)
      --zap-time-encoding timeEncoding   Sets the zap time format ('epoch', 'millis', 'nano', or 'iso8601') (default )

My understanding that is that small fix is enough.
Thanks to discard it if I'm wrong or you already have a better fix.

FYI @cdoan1 