### PR TITLE
Seed userid

### DIFF
--- a/pkg/subscriber/git/git_subscriber.go
+++ b/pkg/subscriber/git/git_subscriber.go
@@ -122,6 +122,8 @@ func (ghs *Subscriber) SubscribeItem(subitem *appv1alpha1.SubscriberItem) error 
 	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationClusterAdmin], "true") {
 		klog.Info("Cluster admin role enabled on SubscriberItem ", ghssubitem.Subscription.Name)
 		ghssubitem.clusterAdmin = true
+		ghssubitem.userID = strings.Trim(subAnnotations[appv1alpha1.AnnotationUserIdentity], "")
+		ghssubitem.userGroup = strings.Trim(subAnnotations[appv1alpha1.AnnotationUserGroup], "")
 	}
 
 	ghssubitem.Start()

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -64,6 +64,7 @@ type SubscriberItem struct {
 	crdsAndNamespaceFiles []string
 	rbacFiles             []string
 	otherFiles            []string
+	subscriptionFiles     []string
 	repoRoot              string
 	commitID              string
 	stopch                chan struct{}
@@ -75,6 +76,8 @@ type SubscriberItem struct {
 	indexFile             *repo.IndexFile
 	webhookEnabled        bool
 	clusterAdmin          bool
+	userID                string
+	userGroup             string
 }
 
 type kubeResource struct {
@@ -311,6 +314,15 @@ func (ghsi *SubscriberItem) subscribeResources(rscFiles []string) error {
 
 				klog.V(4).Info("Applying Kubernetes resource of kind ", t.Kind)
 
+				if ghsi.clusterAdmin && t.Kind == "subscription" {
+					t.Annotations[appv1.AnnotationUserIdentity] = ghsi.userID
+					t.Annotations[appv1.AnnotationUserGroup] = ghsi.userGroup
+					resource, err = yaml.Marshal(&t)
+					if err != nil {
+						klog.Error(err)
+						continue
+					}
+				}
 				ghsi.subscribeResourceFile(resource)
 			}
 		}

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -314,7 +314,8 @@ func (ghsi *SubscriberItem) subscribeResources(rscFiles []string) error {
 
 				klog.V(4).Info("Applying Kubernetes resource of kind ", t.Kind)
 
-				if ghsi.clusterAdmin && t.Kind == "subscription" {
+				// We always override a subscription with the parent(seed) values
+				if t.Kind == "subscription" {
 					t.Annotations[appv1.AnnotationUserIdentity] = ghsi.userID
 					t.Annotations[appv1.AnnotationUserGroup] = ghsi.userGroup
 					resource, err = yaml.Marshal(&t)


### PR DESCRIPTION
* Currently we do not have a way to pass userID and userGroup from a parent subscription to its children.
* This enables that capability for all subscription types. Regardless of whether they are admin or not, so we know where they came from.