### PR TITLE
add setup tests for prow

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -28,6 +28,11 @@ build:
 lint:
 	@build/run-code-lint.sh
 
+.PHONY: setup-tests
+
+setup-tests:
+	@build/setup-tests.sh
+
 .PHONY: test
 
 test: 

--- a/build/setup-tests.sh
+++ b/build/setup-tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+###############################################################################
+# (c) Copyright IBM Corporation 2019, 2020. All Rights Reserved.
+# Note to U.S. Government Users Restricted Rights:
+# U.S. Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+# Copyright (c) Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+###############################################################################
+
+os=$(go env GOOS)
+arch=$(go env GOARCH)
+
+# download kubebuilder and extract it to tmp
+curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+
+rm -rf /usr/local/kubebuilder
+mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

This is only meant for prow. It will install remove the old version kubebuilder and install a newer version of kubebuilder during prow test build.