### PR TITLE
fix setup tests for prow

### DIFF
--- a/build/setup-tests.sh
+++ b/build/setup-tests.sh
@@ -14,5 +14,9 @@ arch=$(go env GOARCH)
 # download kubebuilder and extract it to tmp
 curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
 
-rm -rf /usr/local/kubebuilder
-mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+mkdir -p test_tmp/bin
+_test_bin_dir=$(realpath test_tmp/bin)
+mv /tmp/kubebuilder_2.3.1_${os}_${arch} $_test_bin_dir/kubebuilder
+
+PATH=$_test_bin_dir/kubebuilder/bin:${PATH}
+export PATH


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Not enough permission to remove files/folders on prow. Create a temporary bin folder and set it as the PATH so that it uses the newly download kubebuilder instead of the existing one.