### PR TITLE
remove travis sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ jobs:
         - |
           make
           make component/test/unit
-          make sonar/go
 
     - stage: test-e2e
       name: "Deploy the image to a cluster and run e2e tests"

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include /opt/build-harness/Makefile.prow
+
 IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 export GOPACKAGES   = $(shell go list ./... | grep -v /manager | grep -v /bindata  | grep -v /vendor | grep -v /internal | grep -v /build | grep -v /test | grep -v /e2e )
 
 .PHONY: build
-
--include /opt/build-harness/Makefile.prow
 
 build:
 	@common/scripts/gobuild.sh build/_output/bin/$(IMG) ./cmd/manager
@@ -30,10 +30,8 @@ lint:
 
 .PHONY: setup-tests
 
-setup-tests:
-	@build/setup-tests.sh
-
 .PHONY: test
 
-test: 
+test:
+	@build/setup-tests.sh
 	@build/run-unit-tests.sh


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

sonar scan is now being don in prow and it causes a conflict if its done on travis as well

merging for now please comment if you disagree with the changes here.