### PR TITLE
Merge reconcile namespaces

### DIFF
--- a/pkg/synchronizer/kubernetes/sync_test.go
+++ b/pkg/synchronizer/kubernetes/sync_test.go
@@ -502,6 +502,40 @@ var _ = Describe("harvest existing", func() {
 	})
 })
 
+var _ = Describe("test special resources", func() {
+	It("namespace should be a special resource", func() {
+		result := isSpecialResource(schema.GroupVersionResource{
+			Version:  "v1",
+			Resource: "namespaces",
+		})
+		Expect(result).To(BeFalse())
+	})
+
+	It("serviceaccount should be a special resource", func() {
+		result := isSpecialResource(schema.GroupVersionResource{
+			Version:  "v1",
+			Resource: "serviceaccounts",
+		})
+		Expect(result).To(BeFalse())
+	})
+
+	It("service should be a special resource", func() {
+		result := isSpecialResource(schema.GroupVersionResource{
+			Version:  "v1",
+			Resource: "services",
+		})
+		Expect(result).To(BeFalse())
+	})
+
+	It("configmap should not be a special resource", func() {
+		result := isSpecialResource(schema.GroupVersionResource{
+			Version:  "v1",
+			Resource: "configmaps",
+		})
+		Expect(result).To(BeFalse())
+	})
+})
+
 var _ = Describe("test service resource", func() {
 	var (
 		svcSharedkey = types.NamespacedName{

--- a/pkg/synchronizer/kubernetes/sync_test.go
+++ b/pkg/synchronizer/kubernetes/sync_test.go
@@ -508,7 +508,7 @@ var _ = Describe("test special resources", func() {
 			Version:  "v1",
 			Resource: "namespaces",
 		})
-		Expect(result).To(BeFalse())
+		Expect(result).To(BeTrue())
 	})
 
 	It("serviceaccount should be a special resource", func() {
@@ -516,7 +516,7 @@ var _ = Describe("test special resources", func() {
 			Version:  "v1",
 			Resource: "serviceaccounts",
 		})
-		Expect(result).To(BeFalse())
+		Expect(result).To(BeTrue())
 	})
 
 	It("service should be a special resource", func() {
@@ -524,7 +524,7 @@ var _ = Describe("test special resources", func() {
 			Version:  "v1",
 			Resource: "services",
 		})
-		Expect(result).To(BeFalse())
+		Expect(result).To(BeTrue())
 	})
 
 	It("configmap should not be a special resource", func() {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10347

OCP injects some annotations to namespaces upon creation so namespaces need to be merge updated to preserve those annotations.