### PR TITLE
Reconcile rate settings for helm repo

### DIFF
--- a/docs/helmrepo_subscription.md
+++ b/docs/helmrepo_subscription.md
@@ -1,0 +1,84 @@
+## Resource reconciliation rate settings
+
+The subscription operator compares currently deployed hash of helm chart to the hash from the source repository every 15 munites and apply changes to target clusters when there is change. The frequeny of resource reconciliation has impact on the performance of other application deployments and updates. For example, if there are hundreds of application subscriptions and you choose to reconcile all of these more frequently, the response time of reconcilication will be slower. Depending on the nature of kubernetes resources of the application, it will help to select appropriate reconciliation frequency for better performance.
+
+### Reconcile frequency settings
+
+- `Off` : The deployed resources are not automatically reconciled. A change in the subscription CR triggers a reconciliation. You can add or update a label or annotation.
+- `Low` : The subscription operator compares currently deployed hash to the hash of the source repository every hour and apply changes to target clusters when there is change.
+- `Medium`: This is the default setting. The subscription operator compares currently deployed hash to the hash of the source repository every 15 munites and apply changes to target clusters when there is change.
+- `High`: The subscription operator compares currently deployed hash to the hash of the source repository every 2 munites and apply changes to target clusters when there is change.
+
+You can set this using `apps.open-cluster-management.io/reconcile-rate` annotation in the channel CR that is referenced by subscription. Here is an example.
+
+```yaml
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: helm-channel
+  namespace: sample
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: low
+spec:
+  type: HelmRepo
+  pathname: <Helm repo URL>
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: helm-subscription
+spec:
+  channel: sample/helm-channel
+  name: nginx-ingress
+  packageOverrides:
+  - packageName: nginx-ingress
+    packageAlias: nginx-ingress-simple
+    packageOverrides:
+    - path: spec
+      value:
+        defaultBackend:
+          replicaCount: 3
+  placement:
+    local: true
+```
+
+In this example, all subscriptions that uses `sample/helm-channel` get `low` reconciliation frequency. 
+
+Regardless of the reconcile-rate setting in the channel, a subscription can turn the auto-reconciliation `off` by specifying `apps.open-cluster-management.io/reconcile-rate: off` annotation in the subscription CR. For example, 
+
+```yaml
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: helm-channel
+  namespace: sample
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: high
+spec:
+  type: HelmRepo
+  pathname: <Helm repo URL>
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: helm-subscription
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: "off"
+spec:
+  channel: sample/helm-channel
+  name: nginx-ingress
+  packageOverrides:
+  - packageName: nginx-ingress
+    packageAlias: nginx-ingress-simple
+    packageOverrides:
+    - path: spec
+      value:
+        defaultBackend:
+          replicaCount: 3
+  placement:
+    local: true
+```
+
+In this example, the resources deployed by `helm-subscription` will never be automatically reconciled even if the `reconcile-rate` is set to `high` in the channel.

--- a/pkg/subscriber/git/git_subscriber.go
+++ b/pkg/subscriber/git/git_subscriber.go
@@ -28,6 +28,7 @@ import (
 
 	appv1alpha1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	kubesynchronizer "github.com/open-cluster-management/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
+	"github.com/open-cluster-management/multicloud-operators-subscription/pkg/utils"
 )
 
 type itemmap map[types.NamespacedName]*SubscriberItem
@@ -123,33 +124,11 @@ func (ghs *Subscriber) SubscribeItem(subitem *appv1alpha1.SubscriberItem) error 
 
 	previousReconcileLevel := ghssubitem.reconcileRate
 
-	// If the channel does not have reconcile-level, default it to medium
-	if ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationResourceReconcileLevel] == "" {
-		klog.Info("Setting reconcile-level to default: medium")
-
-		ghssubitem.reconcileRate = "medium"
-	} else {
-		if strings.EqualFold(ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationResourceReconcileLevel], "off") {
-			ghssubitem.reconcileRate = "off"
-		} else if strings.EqualFold(ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationResourceReconcileLevel], "low") {
-			ghssubitem.reconcileRate = "low"
-		} else if strings.EqualFold(ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationResourceReconcileLevel], "medium") {
-			ghssubitem.reconcileRate = "medium"
-		} else if strings.EqualFold(ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationResourceReconcileLevel], "high") {
-			ghssubitem.reconcileRate = "high"
-		} else {
-			klog.Info("Channel's reconcile-level has unknown value: ", ghssubitem.Channel.GetAnnotations()[appv1alpha1.AnnotationResourceReconcileLevel])
-			klog.Info("Setting it to medium")
-
-			ghssubitem.reconcileRate = "medium"
-		}
-	}
+	chnAnnotations := ghssubitem.Channel.GetAnnotations()
 
 	subAnnotations := ghssubitem.Subscription.GetAnnotations()
-	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationClusterAdmin], "true") {
-		klog.Info("Cluster admin role enabled on SubscriberItem ", ghssubitem.Subscription.Name)
-		ghssubitem.clusterAdmin = true
-	}
+
+	ghssubitem.reconcileRate = utils.GetReconcileRate(chnAnnotations, subAnnotations)
 
 	// Reconcile level can be overridden to be
 	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationResourceReconcileLevel], "off") {

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -35,6 +35,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	dplv1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
 	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	kubesynchronizer "github.com/open-cluster-management/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
@@ -103,7 +104,7 @@ func (ghsi *SubscriberItem) Start(restart bool) {
 
 	ghsi.stopch = make(chan struct{})
 
-	loopPeriod, retryInterval, retries := utils.GetReconcileInterval(ghsi.reconcileRate)
+	loopPeriod, retryInterval, retries := utils.GetReconcileInterval(ghsi.reconcileRate, chnv1.ChannelTypeGit)
 
 	if strings.EqualFold(ghsi.reconcileRate, "off") {
 		klog.Infof("auto-reconcile is OFF")

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -115,6 +115,25 @@ func (ghsi *SubscriberItem) Start(restart bool) {
 			klog.Error(err, "Subscription error.")
 		}
 
+		// If the initial subscription fails, retry.
+		n := 0
+
+		for n < retries {
+			if !ghsi.successful {
+				time.Sleep(retryInterval)
+				klog.Infof("Re-try #%d: subcribing to the Git repo", n+1)
+
+				err = ghsi.doSubscription()
+				if err != nil {
+					klog.Error(err, "Subscription error.")
+				}
+
+				n++
+			} else {
+				break
+			}
+		}
+
 		return
 	}
 

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -86,7 +86,7 @@ func (hrsi *SubscriberItem) Start(restart bool) {
 
 	hrsi.stopch = make(chan struct{})
 
-	loopPeriod, retryInterval, retries := utils.GetReconcileInterval(hrsi.reconcileRate)
+	loopPeriod, retryInterval, retries := utils.GetReconcileInterval(hrsi.reconcileRate, chnv1.ChannelTypeHelmRepo)
 
 	if strings.EqualFold(hrsi.reconcileRate, "off") {
 		klog.Infof("auto-reconcile is OFF")

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -93,6 +93,20 @@ func (hrsi *SubscriberItem) Start(restart bool) {
 
 		hrsi.doSubscription()
 
+		// If the initial subscription fails, retry.
+		n := 0
+
+		for n < retries {
+			if !hrsi.success {
+				time.Sleep(retryInterval)
+				klog.Infof("Re-try #%d: subcribing to the Helm repo", n+1)
+				hrsi.doSubscription()
+				n++
+			} else {
+				break
+			}
+		}
+
 		return
 	}
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -1061,7 +1061,7 @@ func GetReconcileRate(chnAnnotations, subAnnotations map[string]string) string {
 }
 
 // GetReconcileInterval determines reconcile loop interval based on reconcileRate setting
-func GetReconcileInterval(reconcileRate string) (time.Duration, time.Duration, int) {
+func GetReconcileInterval(reconcileRate, chType string) (time.Duration, time.Duration, int) {
 	interval := 3 * time.Minute       // reconcile interval
 	retryInterval := 90 * time.Second // re-try interval when reconcile fails
 	retryCount := 1                   // number of re-tries when reconcile fails
@@ -1076,6 +1076,9 @@ func GetReconcileInterval(reconcileRate string) (time.Duration, time.Duration, i
 		klog.Infof("setting auto-reconcile rate to medium")
 
 		interval = 3 * time.Minute // every 3 minutes
+		if strings.EqualFold(chType, chnv1.ChannelTypeHelmRepo) {
+			interval = 15 * time.Minute
+		}
 		retryInterval = 90 * time.Second
 		retryCount = 1
 	} else if strings.EqualFold(reconcileRate, "high") {

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	appv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
@@ -668,32 +669,38 @@ func TestGetReconcileInterval(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	// these intervals are not used if off. Just default values
-	loopPeriod, retryInterval, retries := GetReconcileInterval("off")
+	loopPeriod, retryInterval, retries := GetReconcileInterval("off", chnv1.ChannelTypeGit)
 
 	g.Expect(loopPeriod).To(gomega.Equal(3 * time.Minute))
 	g.Expect(retryInterval).To(gomega.Equal(90 * time.Second))
 	g.Expect(retries).To(gomega.Equal(1))
 
 	// if reconcile rate is unknown, just default values
-	loopPeriod, retryInterval, retries = GetReconcileInterval("unknown")
+	loopPeriod, retryInterval, retries = GetReconcileInterval("unknown", chnv1.ChannelTypeGit)
 
 	g.Expect(loopPeriod).To(gomega.Equal(3 * time.Minute))
 	g.Expect(retryInterval).To(gomega.Equal(90 * time.Second))
 	g.Expect(retries).To(gomega.Equal(1))
 
-	loopPeriod, retryInterval, retries = GetReconcileInterval("low")
+	loopPeriod, retryInterval, retries = GetReconcileInterval("low", chnv1.ChannelTypeGit)
 
 	g.Expect(loopPeriod).To(gomega.Equal(1 * time.Hour))
 	g.Expect(retryInterval).To(gomega.Equal(3 * time.Minute))
 	g.Expect(retries).To(gomega.Equal(3))
 
-	loopPeriod, retryInterval, retries = GetReconcileInterval("medium")
+	loopPeriod, retryInterval, retries = GetReconcileInterval("medium", chnv1.ChannelTypeGit)
 
 	g.Expect(loopPeriod).To(gomega.Equal(3 * time.Minute))
 	g.Expect(retryInterval).To(gomega.Equal(90 * time.Second))
 	g.Expect(retries).To(gomega.Equal(1))
 
-	loopPeriod, retryInterval, retries = GetReconcileInterval("high")
+	loopPeriod, retryInterval, retries = GetReconcileInterval("medium", chnv1.ChannelTypeHelmRepo)
+
+	g.Expect(loopPeriod).To(gomega.Equal(15 * time.Minute))
+	g.Expect(retryInterval).To(gomega.Equal(90 * time.Second))
+	g.Expect(retries).To(gomega.Equal(1))
+
+	loopPeriod, retryInterval, retries = GetReconcileInterval("high", chnv1.ChannelTypeGit)
 
 	g.Expect(loopPeriod).To(gomega.Equal(2 * time.Minute))
 	g.Expect(retryInterval).To(gomega.Equal(60 * time.Second))


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10101

- `Off` : The deployed resources are not automatically reconciled. A change in the subscription CR triggers a reconciliation. You can add or update a label or annotation.
- `Low` : The subscription operator compares currently deployed hash to the hash of the source repository every hour and apply changes to target clusters when there is change.
- `Medium`: This is the default setting. The subscription operator compares currently deployed hash to the hash of the source repository every 15 munites and apply changes to target clusters when there is change.
- `High`: The subscription operator compares currently deployed hash to the hash of the source repository every 2 munites and apply changes to target clusters when there is change.

By giving users option to select reconcile frequency options (high, medium, low and off) in channel configuration, the application or cluster admin can avoid unnecessary resource reconciliations and therefore prevent overload on subscription operator.

Also by adjusting the default resource reconciliation frequency to medium, we can improve initial application deployment performance significantly.

User should be able to override channel's reconcile frequency to OFF.

