### PR TITLE
Fix appmgr pod crash

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -82,7 +82,7 @@ func Add(mgr manager.Manager, hubconfig *rest.Config, syncid *types.NamespacedNa
 	subs[chnv1.ChannelTypeGit] = ghsub.GetDefaultSubscriber()
 	subs[chnv1.ChannelTypeObjectBucket] = ossub.GetDefaultSubscriber()
 
-	return add(mgr, newReconciler(mgr, hubclient, subs, standalone))
+	return add(mgr, newReconciler(mgr, hubclient, subs, standalone), standalone)
 }
 
 type channelMapper struct {
@@ -145,7 +145,7 @@ func newReconciler(mgr manager.Manager, hubclient client.Client, subscribers map
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, standalone bool) error {
 	// Create a new controller
 	c, err := controller.New("subscription-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -158,12 +158,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	err = c.Watch(
-		&source.Kind{Type: &chnv1.Channel{}},
-		&handler.EnqueueRequestsFromMapFunc{ToRequests: &channelMapper{mgr.GetClient()}},
-		utils.ChannelPredicateFunctions)
-	if err != nil {
-		return err
+	if standalone {
+		// There is no channel CRD on a managed cluster
+		err = c.Watch(
+			&source.Kind{Type: &chnv1.Channel{}},
+			&handler.EnqueueRequestsFromMapFunc{ToRequests: &channelMapper{mgr.GetClient()}},
+			utils.ChannelPredicateFunctions)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -121,7 +121,7 @@ func TestReconcileWithoutTimeWindowStatusFlow(t *testing.T) {
 	rec := newReconciler(mgr, mgr.GetClient(), nil, false)
 	recFn, requests := SetupTestReconcile(rec)
 
-	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+	g.Expect(add(mgr, recFn, false)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 
@@ -361,7 +361,7 @@ func TestReconcileWithTimeWindowStatusFlow(t *testing.T) {
 			rec := spyReconciler(mgr, mgr.GetClient(), nil, (&testClock{tt.curTime}).now, true)
 			recFn, reconciliation := ReconcilerSpy(rec)
 
-			g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+			g.Expect(add(mgr, recFn, false)).NotTo(gomega.HaveOccurred())
 
 			// Set the subscription placement to be local so that it is reconciled.
 			pl := &plv1.Placement{}


### PR DESCRIPTION
appmgr pod crashed with 

```E0324 14:12:05.321204       1 manager.go:186] no matches for kind "Channel" in version "apps.open-cluster-management.io/v1"Manager exited non-zero```

