### PR TITLE
set x-kubernetes-preserve-unknown-fields flag to avoid skipping binary data

### DIFF
--- a/deploy/common/apps.open-cluster-management.io_subscriptions.yaml
+++ b/deploy/common/apps.open-cluster-management.io_subscriptions.yaml
@@ -122,6 +122,7 @@ spec:
                     clusterOverrides:
                       items:
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       minItems: 1
                       type: array
                   required:
@@ -209,6 +210,7 @@ spec:
                     packageOverrides:
                       items:
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: array
                   required:
                   - packageName
@@ -435,6 +437,7 @@ spec:
                             type: string
                           resourceStatus:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
                         - lastUpdateTime
                         type: object

--- a/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -122,6 +122,7 @@ spec:
                     clusterOverrides:
                       items:
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       minItems: 1
                       type: array
                   required:
@@ -209,6 +210,7 @@ spec:
                     packageOverrides:
                       items:
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: array
                   required:
                   - packageName
@@ -435,6 +437,7 @@ spec:
                             type: string
                           resourceStatus:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
                         - lastUpdateTime
                         type: object


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/open-cluster-management/backlog/issues/10971

The fix is to avoid the override binary data being skipped in the new V1 appsub CRD. 

e.g. In this appsub resource, the `spec.packageOverrides.packageOverrides` is not saved when the appsub resource is created using the new appsub V1 crd.

```
apiVersion: apps.open-cluster-management.io/v1
kind: Subscription
metadata:
  name: simple
spec:
  channel: dev/dev-helmrepo
  name: nginx-ingress
  placement:
    local: false
  packageOverrides:
  - packageName: nginx-ingress
    packageAlias: nginx-ingress-simple
    packageOverrides:
    - path: spec
      value:
        defaultBackend:
          replicaCount: 3
```