### PR TITLE
app/ReplicaSet is valid group kind

### DIFF
--- a/pkg/synchronizer/kubernetes/discovery.go
+++ b/pkg/synchronizer/kubernetes/discovery.go
@@ -53,11 +53,6 @@ var (
 		Kind:  "ReplicaSet",
 	}
 
-	rsappgk = schema.GroupKind{
-		Group: "apps",
-		Kind:  "ReplicaSet",
-	}
-
 	deployextgk = schema.GroupKind{
 		Group: "extensions",
 		Kind:  "Deployment",
@@ -69,7 +64,6 @@ var (
 	}
 	internalIgnoredGroupKind = map[schema.GroupKind]bool{
 		rsextgk:     true,
-		rsappgk:     true,
 		deployextgk: true,
 		dplgk:       true,
 	}


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/12150

It is recommended to use Deployment instead of app/ReplicaSet but ReplicaSet is still a valid kind. We should not exclude it.