### PR TITLE
Remove orphan appsub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 # This repo is build in Travis-ci by default;
 # Override this variable in local env.
-TRAVIS_BUILD  ?= 1
+TRAVIS_BUILD  ?= 0
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 # This repo is build in Travis-ci by default;
 # Override this variable in local env.
-TRAVIS_BUILD  ?= 0
+TRAVIS_BUILD  ?= 1
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -58,6 +58,11 @@ var (
 		Version: appv1.SchemeGroupVersion.Version,
 		Kind:    "HelmRelease",
 	}
+
+	subscriptionGVK = schema.GroupVersionKind{
+		Group:   appv1.SchemeGroupVersion.Group,
+		Kind:    "Subscription",
+		Version: appv1.SchemeGroupVersion.Version}
 )
 
 // SubscriberItem - defines the unit of namespace subscription
@@ -537,6 +542,13 @@ func (ghsi *SubscriberItem) subscribeResource(file []byte) (*dplv1.Deployable, *
 
 		rsc.SetAnnotations(rscAnnotations)
 	}
+
+	rsc.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: subscriptionGVK.Version,
+		Kind:       subscriptionGVK.Kind,
+		Name:       ghsi.Subscription.Name,
+		UID:        ghsi.Subscription.UID,
+	}})
 
 	dpl.Spec.Template = &runtime.RawExtension{}
 	dpl.Spec.Template.Raw, err = json.Marshal(rsc)

--- a/pkg/utils/deployable.go
+++ b/pkg/utils/deployable.go
@@ -117,11 +117,15 @@ func GetHostDeployableFromObject(obj metav1.Object) *types.NamespacedName {
 
 	hosttr := annotations[dplv1.AnnotationHosting]
 
-	if hosttr == "" {
+	return GetHostDeployable(hosttr)
+}
+
+func GetHostDeployable(hostAnnotation string) *types.NamespacedName {
+	if hostAnnotation == "" {
 		return nil
 	}
 
-	parsedstr := strings.Split(hosttr, "/")
+	parsedstr := strings.Split(hostAnnotation, "/")
 	if len(parsedstr) != 2 {
 		return nil
 	}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/12033

When a managed cluster goes offline, placement decision changes to exclude the managed cluster and then the managed cluster comes back up, the subscription remains on the remote managed cluster even though the managed cluster has been removed from the placement decision.