### PR TITLE
add s3 object bucket subfolder support

### DIFF
--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -84,6 +84,8 @@ var (
 	LabelSubscriptionName = SchemeGroupVersion.Group + "/subscription"
 	// AnnotationHookType defines ansible hook job type - prehook/posthook
 	AnnotationHookType = SchemeGroupVersion.Group + "/hook-type"
+	// AnnotationBucketPath defines s3 object bucket subfolder path
+	AnnotationBucketPath = SchemeGroupVersion.Group + "/bucket-path"
 )
 
 const (

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -334,7 +334,7 @@ func (r *ReconcileSubscription) updateGitSubDeployablesAnnotation(sub *appv1.Sub
 }
 
 func (r *ReconcileSubscription) updateAnnotationTopo(sub *subv1.Subscription, allDpls map[string]*dplv1alpha1.Deployable) error {
-	dplStr, err := updateResourceListViaDeployableMap(allDpls)
+	dplStr, err := updateResourceListViaDeployableMap(allDpls, deployableParent)
 	if err != nil {
 		return gerr.Wrap(err, "failed to parse deployable template")
 	}

--- a/pkg/controller/mcmhub/metaupdate.go
+++ b/pkg/controller/mcmhub/metaupdate.go
@@ -56,11 +56,12 @@ import (
 )
 
 const (
-	sep              = ","
-	sepRes           = "/"
-	deployableParent = "deployable"
-	helmChartParent  = "helmchart"
-	hookParent       = "hook"
+	sep                = ","
+	sepRes             = "/"
+	deployableParent   = "deployable"
+	helmChartParent    = "helmchart"
+	objectBucketParent = "object"
+	hookParent         = "hook"
 )
 
 var _ genericclioptions.RESTClientGetter = &restClientGetter{}
@@ -239,7 +240,7 @@ func getAdditionValue(obj runtime.Object) int {
 }
 
 // generate resource string from a deployable map
-func updateResourceListViaDeployableMap(allDpls map[string]*dplv1.Deployable) (string, error) {
+func updateResourceListViaDeployableMap(allDpls map[string]*dplv1.Deployable, parentType string) (string, error) {
 	res := []string{}
 
 	for _, dpl := range allDpls {
@@ -249,7 +250,7 @@ func updateResourceListViaDeployableMap(allDpls map[string]*dplv1.Deployable) (s
 		}
 
 		rUnit := resourceUnit{
-			parentType: deployableParent,
+			parentType: parentType,
 			namePrefix: "",
 			name:       tpl.GetName(),
 			namespace:  tpl.GetNamespace(),
@@ -263,13 +264,13 @@ func updateResourceListViaDeployableMap(allDpls map[string]*dplv1.Deployable) (s
 	return strings.Join(res, sep), nil
 }
 
-func extracResourceListFromDeployables(sub *appv1.Subscription, allDpls map[string]*dplv1.Deployable) bool {
+func extracResourceListFromDeployables(sub *appv1.Subscription, allDpls map[string]*dplv1.Deployable, parentType string) bool {
 	subanno := sub.GetAnnotations()
 	if len(subanno) == 0 {
 		subanno = make(map[string]string)
 	}
 
-	expectTopo, err := updateResourceListViaDeployableMap(allDpls)
+	expectTopo, err := updateResourceListViaDeployableMap(allDpls, parentType)
 	if err != nil {
 		klog.Errorf("failed to get the resource info for subscription %v, err: %v", ObjectString(sub), err)
 		return false

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
@@ -196,11 +196,20 @@ func generateDplNameFromKey(key string) string {
 func (obsi *SubscriberItem) doSubscription() error {
 	var dpls []*dplv1.Deployable
 
-	keys, err := obsi.objectStore.List(obsi.bucket)
+	var folderName *string
+
+	annotations := obsi.Subscription.GetAnnotations()
+	bucketPath := annotations[appv1.AnnotationBucketPath]
+
+	if bucketPath != "" {
+		folderName = &bucketPath
+	}
+
+	keys, err := obsi.objectStore.List(obsi.bucket, folderName)
 	klog.V(5).Infof("object keys: %v", keys)
 
 	if err != nil {
-		klog.Info("Failed to list objects in bucket ", obsi.bucket)
+		klog.Error("Failed to list objects in bucket ", obsi.bucket)
 
 		return err
 	}
@@ -209,7 +218,8 @@ func (obsi *SubscriberItem) doSubscription() error {
 	for _, key := range keys {
 		tplb, err := obsi.objectStore.Get(obsi.bucket, key)
 		if err != nil {
-			klog.Info("Failed to get object ", key, " in bucket ", obsi.bucket)
+			klog.Error("Failed to get object ", key, " in bucket ", obsi.bucket)
+
 			return err
 		}
 

--- a/pkg/utils/aws/objectstore_test.go
+++ b/pkg/utils/aws/objectstore_test.go
@@ -59,11 +59,11 @@ func TestObjectstore(t *testing.T) {
 	g.Expect(err).To(gomega.HaveOccurred())
 
 	// List items in the bucket
-	buckets, err := awshandler.List("test")
+	buckets, err := awshandler.List("test", nil)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(len(buckets)).To(gomega.Equal(0))
 
-	_, err = awshandler.List("notest")
+	_, err = awshandler.List("notest", nil)
 	g.Expect(err).To(gomega.HaveOccurred())
 
 	// Put items into the bucket


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

- allows subfolder object bucket subscription based on an annotation: api group `/bucket-path`
- perform an object bucket hub subscription "dryrun" to see which objects will be deployed when subscribed
- populate the topology annotation according according to the result of the dryrun. They are now categorized under "object" instead of previously "deployable"

see https://github.com/open-cluster-management/backlog/issues/12344 and https://github.com/open-cluster-management/backlog/issues/12510