### PR TITLE
revert to apply cached client; update appsub status if object bucket …

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -274,7 +274,10 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 			if reconcileErr != nil {
 				instance.Status.Phase = appv1.SubscriptionFailed
 				instance.Status.Reason = reconcileErr.Error()
-				instance.Status.Statuses = nil
+
+				var emptyStatuses appv1.SubscriptionClusterStatusMap
+				emptyStatuses = make(appv1.SubscriptionClusterStatusMap)
+				instance.Status.Statuses = emptyStatuses
 
 				klog.Errorf("doReconcile got error %v", reconcileErr)
 			}

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -275,8 +275,7 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 				instance.Status.Phase = appv1.SubscriptionFailed
 				instance.Status.Reason = reconcileErr.Error()
 
-				var emptyStatuses appv1.SubscriptionClusterStatusMap
-				emptyStatuses = make(appv1.SubscriptionClusterStatusMap)
+				var emptyStatuses appv1.SubscriptionClusterStatusMap = make(appv1.SubscriptionClusterStatusMap)
 				instance.Status.Statuses = emptyStatuses
 
 				klog.Errorf("doReconcile got error %v", reconcileErr)

--- a/pkg/synchronizer/kubernetes/sync_server.go
+++ b/pkg/synchronizer/kubernetes/sync_server.go
@@ -145,29 +145,8 @@ func CreateSynchronizer(config, remoteConfig *rest.Config, scheme *runtime.Schem
 		s.RemoteClient = s.remoteCachedClient.clt
 	}
 
-	// create non cached local/hub client ONLY for local/hub subscription status update
-	// the latest updated local subscription status won't be fetched rigt away by cached client,
-	// So the subscription status fast conitinous update could easily fail when using cached client.
-	// As subscription status update does not usually happen, applying non cached client to it won't impact performance too much.
-	nonCachedLocalClient, err := client.New(config, client.Options{})
-	if err != nil {
-		klog.Error("Failed to initialize non cached local client. err: ", err)
-
-		return nil, err
-	}
-
-	nonCachedRemoteClient := nonCachedLocalClient
-	if remoteConfig != nil {
-		nonCachedRemoteClient, err = client.New(remoteConfig, client.Options{})
-		if err != nil {
-			klog.Error("Failed to initialize non cached remote client. err: ", err)
-
-			return nil, err
-		}
-	}
-
-	defaultExtension.localClient = nonCachedLocalClient
-	defaultExtension.remoteClient = nonCachedRemoteClient
+	defaultExtension.localClient = s.LocalClient
+	defaultExtension.remoteClient = s.RemoteClient
 
 	if ext == nil {
 		s.Extension = defaultExtension


### PR DESCRIPTION
…connection fails

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

I turns out the non cached client applied to the appsub status update also has GET api calls. So using non cached client does impact the performance dramatically. The fix is to revert to apply cached client when the appsub status is updated
