### PR TITLE
add helmrepo fail status

### DIFF
--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -92,7 +92,7 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1alpha1.Subscription)
 	case chnv1alpha1.ChannelTypeGit, chnv1alpha1.ChannelTypeGitHub:
 		updateSubDplAnno, err = r.UpdateGitDeployablesAnnotation(sub)
 	case chnv1alpha1.ChannelTypeHelmRepo:
-		updateSubDplAnno = UpdateHelmTopoAnnotation(r.Client, r.cfg, sub, channel.Spec.InsecureSkipVerify)
+		updateSubDplAnno, err = UpdateHelmTopoAnnotation(r.Client, r.cfg, sub, channel.Spec.InsecureSkipVerify)
 	case chnv1alpha1.ChannelTypeObjectBucket:
 		updateSubDplAnno, err = r.updateObjectBucketAnnotation(sub, channel, objectBucketParent)
 	default:


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/13138

When the helm repo URL is incorrect, you will see hub subscription status like this with this change.

```
status:
  lastUpdateTime: "2021-06-09T14:06:31Z"
  phase: PropagationFailed
  reason: 'unable to retrieve the helm repo index https://artifacthub.io/packages/helm/bitnami/nginx: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type repo.IndexFile'
```