### PR TITLE
support AWS S3 bucket pagination for listing over 1000 objects

### DIFF
--- a/pkg/utils/aws/objectstore.go
+++ b/pkg/utils/aws/objectstore.go
@@ -213,7 +213,7 @@ func (h *Handler) List(bucket string, folderName *string) ([]string, error) {
 
 	var keys []string
 
-	var err error
+	var objErr error
 
 	pageNum := 0
 
@@ -221,6 +221,7 @@ func (h *Handler) List(bucket string, folderName *string) ([]string, error) {
 		output, err := paginator.NextPage(context.TODO())
 		if err != nil {
 			klog.Infof("Got error retrieving list of objects. err: %v", err)
+			objErr = err
 
 			break
 		}
@@ -236,9 +237,9 @@ func (h *Handler) List(bucket string, folderName *string) ([]string, error) {
 		pageNum++
 	}
 
-	klog.V(1).Infof("List S3 Objects result, page Num: %v, keys: %v, err: %v ", pageNum, keys, err)
+	klog.Infof("List S3 Objects result, page Num: %v, keys: %v, err: %v ", pageNum, keys, objErr)
 
-	return keys, err
+	return keys, objErr
 }
 
 // Get get existing object.


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/open-cluster-management/backlog/issues/13642

AWS S3 enforces the 1000 object list per request. The fix is to apply pagination when listing objects to make sure all objects (> 1000) is able to be fetched.