### PR TITLE
[WIP] update host subscription deployable status when fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 # This repo is build in Travis-ci by default;
 # Override this variable in local env.
-TRAVIS_BUILD  ?= 0
+TRAVIS_BUILD  ?= 1
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.

--- a/pkg/subscriber/git/git_subscriber.go
+++ b/pkg/subscriber/git/git_subscriber.go
@@ -36,6 +36,7 @@ type itemmap map[types.NamespacedName]*SubscriberItem
 type SyncSource interface {
 	GetInterval() int
 	GetLocalClient() client.Client
+	GetRemoteClient() client.Client
 	GetValidatedGVK(schema.GroupVersionKind) *schema.GroupVersionKind
 	IsResourceNamespaced(schema.GroupVersionKind) bool
 	AddTemplates(string, types.NamespacedName, []kubesynchronizer.DplUnit) error

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -325,6 +325,7 @@ func (ghsi *SubscriberItem) doSubscription() error {
 				klog.Error("Failed to update subscription status with the error. again")
 			}
 		}
+
 		return errors.New("failed to prepare resources to apply and there is no resource to apply. err: " + errMsg)
 	}
 

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -317,20 +317,22 @@ func (ghsi *SubscriberItem) doSubscription() error {
 	// If it failed to add applicable resources to the list, do not apply the empty list.
 	// It will cause already deployed resourced to be removed.
 	// Update the host deployable status accordingly and quit.
-	if len(ghsi.resources) == 0 && !ghsi.successful && (ghsi.synchronizer.GetRemoteClient() != nil) && !standaloneSubscription {
-		klog.Error("failed to prepare resources to apply and there is no resource to apply. quit")
+	if len(ghsi.resources) == 0 && !ghsi.successful {
+		if (ghsi.synchronizer.GetRemoteClient() != nil) && !standaloneSubscription {
+			klog.Error("failed to prepare resources to apply and there is no resource to apply. quit")
 
-		statusErr := utils.UpdateDeployableStatus(ghsi.synchronizer.GetRemoteClient(), errors.New(errMsg), ghsi.Subscription, nil)
+			statusErr := utils.UpdateDeployableStatus(ghsi.synchronizer.GetRemoteClient(), errors.New(errMsg), ghsi.Subscription, nil)
 
-		if statusErr != nil {
-			klog.Error("Failed to update subscription status with the error. Trying again in 2 seconds")
+			if statusErr != nil {
+				klog.Error("Failed to update subscription status with the error. Trying again in 2 seconds")
 
-			time.Sleep(2 * time.Second)
+				time.Sleep(2 * time.Second)
 
-			statusErr2 := utils.UpdateDeployableStatus(ghsi.synchronizer.GetRemoteClient(), errors.New(errMsg), ghsi.Subscription, nil)
+				statusErr2 := utils.UpdateDeployableStatus(ghsi.synchronizer.GetRemoteClient(), errors.New(errMsg), ghsi.Subscription, nil)
 
-			if statusErr2 != nil {
-				klog.Error("Failed to update subscription status with the error. again")
+				if statusErr2 != nil {
+					klog.Error("Failed to update subscription status with the error. again")
+				}
 			}
 		}
 

--- a/pkg/synchronizer/kubernetes/sync_client.go
+++ b/pkg/synchronizer/kubernetes/sync_client.go
@@ -45,6 +45,7 @@ type resourceOrder struct {
 type SyncSource interface {
 	GetInterval() int
 	GetLocalClient() client.Client
+	GetRemoteClient() client.Client
 	GetValidatedGVK(schema.GroupVersionKind) *schema.GroupVersionKind
 	IsResourceNamespaced(schema.GroupVersionKind) bool
 	AddTemplates(string, types.NamespacedName, []DplUnit) error
@@ -57,6 +58,10 @@ func (sync *KubeSynchronizer) GetInterval() int {
 
 func (sync *KubeSynchronizer) GetLocalClient() client.Client {
 	return sync.LocalClient
+}
+
+func (sync *KubeSynchronizer) GetRemoteClient() client.Client {
+	return sync.RemoteClient
 }
 
 // GetValidatedGVK return right gvk from original


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/13603

When Git subscription fails on managed cluster, update the host subscription deployable status.