### PR TITLE
change hub git watch interval to one hour

### DIFF
--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -39,7 +39,6 @@ import (
 )
 
 const (
-	hookInterval     = time.Second * 180
 	gitWatchInterval = time.Hour
 	commitIDSuffix   = "-new"
 )

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -39,8 +39,9 @@ import (
 )
 
 const (
-	hookInterval   = time.Second * 180
-	commitIDSuffix = "-new"
+	hookInterval     = time.Second * 180
+	gitWatchInterval = time.Hour
+	commitIDSuffix   = "-new"
 )
 
 type GitOps interface {
@@ -144,7 +145,7 @@ func NewHookGit(clt client.Client, ops ...HubGitOption) *HubGitOps {
 	hGit := &HubGitOps{
 		clt:                 clt,
 		mtx:                 sync.Mutex{},
-		watcherInterval:     hookInterval,
+		watcherInterval:     gitWatchInterval,
 		subRecords:          map[types.NamespacedName]string{},
 		repoRecords:         map[string]*RepoRegistery{},
 		downloadDirResolver: utils.GetLocalGitFolder,
@@ -469,6 +470,10 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) error {
 
 		return nil
 	}
+
+	h.logger.Info("setting the latest commit ID to ", commitID)
+
+	subscriptionRepoInfo.branchs[branchInfoName].lastCommitID = commitID
 
 	// Pick up new channel configurations
 	subscriptionRepoInfo.branchs[branchInfoName].gitCloneOptions = *cloneOptions


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/14624

Change the hub Git watch interval from 3 minutes to 1 hour. Managed clusters reconcile based on the reconcile-rate setting and triggers hub to reconcile.