### PR TITLE
[WIP] reduce git clones by hub

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -601,7 +601,6 @@ func (r *ReconcileSubscription) createDeployable(
 
 			if err := r.Client.Update(context.TODO(), dpl); err != nil {
 				klog.Error("Failed to update deployable.")
-				return err
 			}
 
 			return nil


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/14624


Change the Hub Git commit check interval from 3 minutes to 1 hour. Let managed clusters's status update trigger Hub Git commit check.