### PR TITLE
appsub controller failed to start after k8s api upgrade

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -86,11 +86,11 @@ func RunManager() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-		Port:                    operatorMetricsPort,
-		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        leaderElectionID,
-		LeaderElectionNamespace: "kube-system",
+		MetricsBindAddress:         fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		Port:                       operatorMetricsPort,
+		LeaderElection:             enableLeaderElection,
+		LeaderElectionID:           leaderElectionID,
+		LeaderElectionResourceLock: "configmaps",
 	})
 
 	if err != nil {

--- a/pkg/subscriber/namespace/namespace_subscriber.go
+++ b/pkg/subscriber/namespace/namespace_subscriber.go
@@ -182,7 +182,7 @@ func (ns *NsSubscriber) initializeSubscriber(nssubitem *NsSubscriberItem,
 
 	dplReconciler := NewNsDeployableReconciler(hubclient, ns, itemkey)
 
-	nssubitem.deployablecontroller, err = controller.New("sub"+itemkey.String(), ns.manager, controller.Options{Reconciler: dplReconciler})
+	nssubitem.deployablecontroller, err = controller.New("sub-deployable-"+itemkey.String(), ns.manager, controller.Options{Reconciler: dplReconciler})
 
 	if err != nil {
 		return errors.Wrap(err, "failed to create deployable controller for namespace subscriber item")
@@ -204,7 +204,7 @@ func (ns *NsSubscriber) initializeSubscriber(nssubitem *NsSubscriberItem,
 
 	secretreconciler := newSecretReconciler(ns, ns.manager, itemkey)
 
-	nssubitem.secretcontroller, err = controller.New("sub"+itemkey.String(), ns.manager, controller.Options{Reconciler: secretreconciler})
+	nssubitem.secretcontroller, err = controller.New("sub-secret-"+itemkey.String(), ns.manager, controller.Options{Reconciler: secretreconciler})
 
 	if err != nil {
 		return errors.Wrap(err, "failed to create secret controller for namespace subscriber item")
@@ -231,20 +231,6 @@ func (ns *NsSubscriber) initializeSubscriber(nssubitem *NsSubscriberItem,
 		err := nssubitem.cache.Start(ctx)
 		if err != nil {
 			klog.Error("failed to start cache for Namespace subscriber item with error: ", err)
-		}
-	}()
-
-	go func() {
-		err := nssubitem.deployablecontroller.Start(ctx)
-		if err != nil {
-			klog.Error("failed to start controller for Namespace subscriber item with error: ", err)
-		}
-	}()
-
-	go func() {
-		err := nssubitem.secretcontroller.Start(ctx)
-		if err != nil {
-			klog.Error("failed to start controller for Namespace subscriber item with error: ", err)
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/open-cluster-management/backlog/issues/15436

Two issues are addressed:

1.  Leader Election lock supports three types of locks along with the new k8s api. - configmap, lease and endpoint. LeaderElectionResourceLock has to be specified. We do see leader election  lock with configmap type is fetched but leader election lock with lease type is updated, that caused the leader election lock update failure.
```
E0819 22:29:52.489821       1 leaderelection.go:361] Failed to update lock: Put "https://10.43.0.1:443/api/v1/namespaces/open-cluster-management-agent-addon/leases/multicloud-operators-remote-subscription-leader.open-cluster-management.io": context canceled
```

2. In namespace subscriber,  deployable and secret controller have been started with different context before the manager start.  In the new k8s api, this causes the following error.   
```
E0819 22:29:52.489963       1 manager.go:191] controller was started more than once. This is likely to be caused by being added to a manager multiple times
```
The fix has been verified in ACM 2.4 cluster. 
1.  the managed subscription controller is able to be started.
2. the namespace subscription is working  - the hub appsub is able to be propagated to managed clusters as expected