### PR TITLE
convert invalid deployable name

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -557,12 +557,7 @@ func (r *ReconcileSubscription) createDeployable(
 	dpl.Name = strings.ToLower(sub.Name + "-" + prefix + obj.GetName() + "-" + obj.GetKind())
 
 	// Replace special characters with -
-	re, reErr := regexp.Compile(`[^\w]`)
-
-	if reErr != nil {
-		klog.Error("Failed to compile regular expression [^\\w]")
-		return reErr
-	}
+	re := regexp.MustCompile(`[^\w]`)
 
 	dpl.Name = re.ReplaceAllString(dpl.Name, "-")
 

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -554,6 +555,17 @@ func (r *ReconcileSubscription) createDeployable(
 	}
 
 	dpl.Name = strings.ToLower(sub.Name + "-" + prefix + obj.GetName() + "-" + obj.GetKind())
+
+	// Replace special characters with -
+	re, reErr := regexp.Compile(`[^\w]`)
+
+	if reErr != nil {
+		klog.Error("Failed to compile regular expression [^\\w]")
+		return reErr
+	}
+
+	dpl.Name = re.ReplaceAllString(dpl.Name, "-")
+
 	klog.Info("Creating a deployable " + dpl.Name)
 
 	if len(dpl.Name) > 252 { // kubernetest resource name length limit


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/15803

Some kubernetes resources such as clusterrole allows the resource name to not follow a DNS subdomain name as defined in RFC 1123. When we use such resource name to create deployables, it breaks.

```
status:
  lastUpdateTime: '2021-09-02T17:02:37Z'
  phase: PropagationFailed
  reason: >-
    Deployable.apps.open-cluster-management.io
    "non-openshift-olm-subscription-1-olm-system:controller:operator-lifecycle-manager-clusterrole"
    is invalid: metadata.name: Invalid value:
    "non-openshift-olm-subscription-1-olm-system:controller:operator-lifecycle-manager-clusterrole":
    a lowercase RFC 1123 subdomain must consist of lower case alphanumeric
    characters, '-' or '.', and must start and end with an alphanumeric
    character (e.g. 'example.com', regex used for validation is
    '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')/n
```