### PR TITLE
fix synchronizer to apply only appsub resources

### DIFF
--- a/pkg/subscriber/namespace/secret_reconciler_test.go
+++ b/pkg/subscriber/namespace/secret_reconciler_test.go
@@ -111,6 +111,14 @@ var _ = Describe("base secret reconcile", func() {
 		// pointing to a namespace type of channel
 		srtRec := newSecretReconciler(defaultNsSubscriber, k8sManager, subkey)
 
+		k8sClient.Create(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "srt-test-sub-namespace"},
+		})
+
+		k8sClient.Create(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "tch"},
+		})
+
 		// Create secrets at the channel namespace
 
 		Expect(k8sClient.Create(context.TODO(), subscription)).NotTo(HaveOccurred())

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -381,21 +381,17 @@ func isSpecialResource(gvr schema.GroupVersionResource) bool {
 func (sync *KubeSynchronizer) applyKindTemplates(res *ResourceMap, keySet map[string]bool) {
 	nri := sync.DynamicClient.Resource(res.GroupVersionResource)
 
-	for k, tplunit := range res.TemplateMap {
-		klog.V(1).Infof("k: %v, res.GroupVersionResource: %v", k, res.GroupVersionResource)
+	for resourceKey, okVal := range keySet {
+		tplunit := res.TemplateMap[resourceKey]
 
-		if !keySet[k] {
-			// ketSet contains resource keys to be deployed for this sinigle subscription item.
-			// if the current resource from the template map does not belong to ketSet,
-			// it belongs to another subscription. Skip.
-			klog.V(1).Infof("k: %v, does not belong to the order to be processed. skip", k)
-			continue
-		}
+		if okVal && tplunit != nil {
+			klog.Infof("applying kind template with key: %v,", resourceKey)
 
-		err := sync.applyTemplate(nri, res.Namespaced, k, tplunit, isSpecialResource(res.GroupVersionResource))
+			err := sync.applyTemplate(nri, res.Namespaced, resourceKey, tplunit, isSpecialResource(res.GroupVersionResource))
 
-		if err != nil {
-			klog.Error("Failed to apply kind template", tplunit.Unstructured, "with error:", err)
+			if err != nil {
+				klog.Error("Failed to apply kind template", tplunit.Unstructured, "with error:", err)
+			}
 		}
 	}
 }

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -392,6 +392,8 @@ func (sync *KubeSynchronizer) applyKindTemplates(res *ResourceMap, keySet map[st
 			if err != nil {
 				klog.Error("Failed to apply kind template", tplunit.Unstructured, "with error:", err)
 			}
+		} else {
+			klog.Errorf("kind template with key %v not found", resourceKey)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Fix the synchronizer to search for specific resources with provided keys instead of looping though everything.