### PR TITLE
Install the policy generator Kustomize plugin

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,14 @@
+FROM registry.ci.openshift.org/open-cluster-management/builder:go1.16-linux AS plugin-builder
+ENV POLICY_GENERATOR_TAG=v1.0.0
+
+WORKDIR /policy-generator
+RUN curl -L -o "policy-generator-plugin.tar.gz" \
+        "https://github.com/open-cluster-management/policy-generator-plugin/archive/refs/tags/${POLICY_GENERATOR_TAG}.tar.gz"
+RUN tar -xzvf "policy-generator-plugin.tar.gz"
+RUN cd "/policy-generator/policy-generator-plugin-${POLICY_GENERATOR_TAG#*v}" && \
+        make build-binary && \
+        mv "PolicyGenerator" "/policy-generator/"
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN  microdnf update -y \ 
@@ -10,11 +21,16 @@ RUN  microdnf update -y \
 ENV OPERATOR=/usr/local/bin/multicluster-operators-subscription \
     USER_UID=1001 \
     USER_NAME=multicluster-operators-subscription \
-    ZONEINFO=/usr/share/timezone
+    ZONEINFO=/usr/share/timezone \
+    KUSTOMIZE_PLUGIN_HOME=/etc/kustomize/plugin
 
 # install operator binary
 COPY build/_output/bin/multicluster-operators-subscription ${OPERATOR}
 COPY build/_output/bin/uninstall-crd /usr/local/bin
+
+# install the policy generator Kustomize plugin
+RUN mkdir -p $KUSTOMIZE_PLUGIN_HOME/policy.open-cluster-management.io/v1/policygenerator
+COPY --from=plugin-builder /policy-generator/PolicyGenerator $KUSTOMIZE_PLUGIN_HOME/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,8 +1,17 @@
 FROM registry.ci.openshift.org/open-cluster-management/builder:go1.16-linux AS builder
+ENV POLICY_GENERATOR_TAG=v1.0.0
 
 WORKDIR /go/src/github.com/open-cluster-management/multicluster-operators-subscription
 COPY . .
 RUN make -f Makefile.prow build
+
+WORKDIR /policy-generator
+RUN curl -L -o "policy-generator-plugin.tar.gz" \
+        "https://github.com/open-cluster-management/policy-generator-plugin/archive/refs/tags/${POLICY_GENERATOR_TAG}.tar.gz"
+RUN tar -xzvf "policy-generator-plugin.tar.gz"
+RUN cd "/policy-generator/policy-generator-plugin-${POLICY_GENERATOR_TAG#*v}" && \
+        make build-binary && \
+        mv "PolicyGenerator" "/policy-generator/"
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
@@ -16,11 +25,16 @@ RUN  microdnf update -y \
 ENV OPERATOR=/usr/local/bin/multicluster-operators-subscription \
     USER_UID=1001 \
     USER_NAME=multicluster-operators-subscription \
-    ZONEINFO=/usr/share/timezone
+    ZONEINFO=/usr/share/timezone \
+    KUSTOMIZE_PLUGIN_HOME=/etc/kustomize/plugin
 
 # install operator binary
 COPY --from=builder /go/src/github.com/open-cluster-management/multicluster-operators-subscription/build/_output/bin/multicluster-operators-subscription ${OPERATOR}
 COPY --from=builder /go/src/github.com/open-cluster-management/multicluster-operators-subscription/build/_output/bin/uninstall-crd /usr/local/bin
+
+# install the policy generator Kustomize plugin
+RUN mkdir -p $KUSTOMIZE_PLUGIN_HOME/policy.open-cluster-management.io/v1/policygenerator
+COPY --from=builder /policy-generator/PolicyGenerator $KUSTOMIZE_PLUGIN_HOME/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup


### PR DESCRIPTION
This is required for the policy generator to be integrated into ACM
GitOps. For more information on the policy generator, see the JIRA
epic ACM-699.

Resolves:
https://github.com/open-cluster-management/backlog/issues/15929