### PR TITLE
fix SSH known_hosts file create problem

### DIFF
--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -177,6 +177,19 @@ func getConnectionOptions(cloneOptions *GitCloneOption, primary bool) (connectio
 		ReferenceName:     cloneOptions.Branch,
 	}
 
+	// The destination directory needs to be created here
+	err = os.RemoveAll(cloneOptions.DestDir)
+
+	if err != nil {
+		klog.Warning(err, "Failed to remove directory ", cloneOptions.DestDir)
+	}
+
+	err = os.MkdirAll(cloneOptions.DestDir, os.ModePerm)
+
+	if err != nil {
+		return nil, err
+	}
+
 	if strings.HasPrefix(options.URL, "http") {
 		klog.Info("Connecting to Git server via HTTP")
 
@@ -216,18 +229,6 @@ func getConnectionOptions(cloneOptions *GitCloneOption, primary bool) (connectio
 			klog.Info("Setting clone depth to 20")
 			options.Depth = 20
 		}
-	}
-
-	err = os.RemoveAll(cloneOptions.DestDir)
-
-	if err != nil {
-		klog.Warning(err, "Failed to remove directory ", cloneOptions.DestDir)
-	}
-
-	err = os.MkdirAll(cloneOptions.DestDir, os.ModePerm)
-
-	if err != nil {
-		return nil, err
 	}
 
 	return options, nil


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/16259

```
I0917 18:37:04.942649       1 gitrepo.go:398] SSH host key: bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
E0917 18:37:04.942692       1 gitrepo.go:401] failed to write known_hosts file: open /tmp/gitssh-subscription-local/master/known_hosts: no such file or directory
E0917 18:37:04.942723       1 gitrepo.go:243] Failed to get Git clone options with the primary channel. Trying the secondary channel.
```