### PR TITLE
allow appsub admin to deploy policies

### DIFF
--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -806,7 +806,7 @@ func (r *ReconcileSubscription) updateSubAnnotations(sub *appv1alpha1.Subscripti
 		subepanno[appv1alpha1.AnnotationBucketPath] = origsubanno[appv1alpha1.AnnotationBucketPath]
 	}
 
-	if !strings.EqualFold(origsubanno[appv1alpha1.AnnotationClusterAdmin], "") {
+	if !strings.EqualFold(origsubanno[appv1alpha1.AnnotationClusterAdmin], "") && r.AddClusterAdminAnnotation(sub) {
 		subepanno[appv1alpha1.AnnotationClusterAdmin] = origsubanno[appv1alpha1.AnnotationClusterAdmin]
 	}
 

--- a/pkg/subscriber/git/git_subscriber.go
+++ b/pkg/subscriber/git/git_subscriber.go
@@ -135,11 +135,15 @@ func (ghs *Subscriber) SubscribeItem(subitem *appv1alpha1.SubscriberItem) error 
 	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationClusterAdmin], "true") {
 		klog.Info("Cluster admin role enabled on SubscriberItem ", ghssubitem.Subscription.Name)
 		ghssubitem.clusterAdmin = true
+	} else {
+		ghssubitem.clusterAdmin = false
 	}
 
 	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationCurrentNamespaceScoped], "true") {
 		klog.Info("CurrentNamespaceScoped enabled on SubscriberItem ", ghssubitem.Subscription.Name)
 		ghssubitem.currentNamespaceScoped = true
+	} else {
+		ghssubitem.currentNamespaceScoped = false
 	}
 
 	ghssubitem.desiredCommit = subAnnotations[appv1alpha1.AnnotationGitTargetCommit]

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -406,6 +406,12 @@ func (sync *KubeSynchronizer) applyKindTemplates(res *ResourceMap, keySet map[st
 				} else {
 					denyError := fmt.Errorf("the resource apiVersion: %s kind: %s is not on the allow list. Not deployed",
 						tplunit.GetAPIVersion(), tplunit.GetKind())
+
+					if !isAdmin {
+						denyError = fmt.Errorf("not deployed by a subscription admin. the resource apiVersion: %s kind: %s is not deployed",
+							tplunit.GetAPIVersion(), tplunit.GetKind())
+					}
+
 					klog.Info(denyError.Error())
 
 					err := sync.Extension.UpdateHostStatus(denyError, tplunit.Unstructured, nil, false)

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -896,22 +896,19 @@ func AllowApplyTemplate(localClient client.Client, template *unstructured.Unstru
 // IsResourceAllowed checks if the resource is on application subscription's allow list. The allow list is used only
 // if the subscription is created by subscription-admin user.
 func IsResourceAllowed(resource unstructured.Unstructured, allowlist map[string]map[string]string, isAdmin bool) bool {
-	// Policy is not allowed by default
-	allowed := resource.GetAPIVersion() != "policy.open-cluster-management.io/v1"
-
 	// If subscription-admin, honor the allow list
 	if isAdmin {
 		// If allow list is empty, all resources are allowed for deploy except the policy
 		if len(allowlist) == 0 {
-			return allowed
+			return true
 		}
 
 		return (allowlist[resource.GetAPIVersion()][resource.GetKind()] != "" ||
 			allowlist[resource.GetAPIVersion()]["*"] != "")
 	}
 
-	// If not subscription-admin, ignore the allow list
-	return allowed
+	// If not subscription-admin, ignore the allow list and don't allow policy
+	return resource.GetAPIVersion() != "policy.open-cluster-management.io/v1"
 }
 
 // IsResourceDenied checks if the resource is on application subscription's deny list. The deny list is used only


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Allow subscriptions created by a subscription admin to deploy/reconcile ACM policy resources.

Also fix subscription admin annotation verification so that when a non subscription admin tries to add `apps.open-cluster-management.io/cluster-admin: "true"` annotation to subscription, it gets removed.