### PR TITLE
for managed cluster subscription it should not have an owner reference

### DIFF
--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -671,6 +671,8 @@ func (r *ReconcileSubscription) prepareDeployableForSubscription(sub, rootSub *a
 	subep.Generation = 1
 	subep.SelfLink = ""
 
+	subep.OwnerReferences = nil
+
 	subepanno := r.updateSubAnnotations(sub)
 
 	if rootSub == nil {


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

flowing from upstream https://github.com/open-cluster-management-io/multicloud-operators-subscription/pull/33