### PR TITLE
fix helmrelease configmap and secret refs

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -68,7 +68,7 @@ linters-settings:
     min-confidence: 0.0
   gocognit:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 80
+    min-complexity: 85
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -72,10 +72,10 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1alpha1.Subscription)
 
 	if (primaryChannel != nil && secondaryChannel != nil) &&
 		(primaryChannel.Spec.Type != secondaryChannel.Spec.Type) {
-		klog.Errorf("he type of primary and secondary channels is different. primary channel type: %s, secondary channel type: %s",
+		klog.Errorf("the type of primary and secondary channels is different. primary channel type: %s, secondary channel type: %s",
 			primaryChannel.Spec.Type, secondaryChannel.Spec.Type)
 
-		newError := fmt.Errorf("he type of primary and secondary channels is different. primary channel type: %s, secondary channel type: %s",
+		newError := fmt.Errorf("the type of primary and secondary channels is different. primary channel type: %s, secondary channel type: %s",
 			primaryChannel.Spec.Type, secondaryChannel.Spec.Type)
 
 		return newError

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -606,6 +606,7 @@ func (r *ReconcileSubscription) Reconcile(ctx context.Context, request reconcile
 				}
 			}
 		}
+
 		//changes will be added to instance
 		err = r.doMCMHubReconcile(instance)
 

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -433,6 +433,12 @@ func getHelmRepoIndex(client rest.HTTPClient, sub *appv1.Subscription,
 		return nil, "", err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		klog.Errorf("http request %s failed: status %s", cleanRepoURL, resp.Status)
+
+		return nil, "", fmt.Errorf("http request %s failed: status %s", cleanRepoURL, resp.Status)
+	}
+
 	klog.V(5).Info("Get succeeded: ", cleanRepoURL)
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -198,11 +198,27 @@ func CreateOrUpdateHelmChart(
 			return nil, err
 		}
 
+		if secondaryChannel.Spec.ConfigMapRef != nil {
+			secondaryChannel.Spec.ConfigMapRef.Namespace = secondaryChannel.Namespace
+		}
+
+		if secondaryChannel.Spec.SecretRef != nil {
+			secondaryChannel.Spec.SecretRef.Namespace = secondaryChannel.Namespace
+		}
+
 		altSource.ConfigMapRef = secondaryChannel.Spec.ConfigMapRef
 		altSource.InsecureSkipVerify = secondaryChannel.Spec.InsecureSkipVerify
 		altSource.SecretRef = secondaryChannel.Spec.SecretRef
 
 		klog.Infof("Created altSource for helmRelease %s", releaseCRName)
+	}
+
+	if channel.Spec.ConfigMapRef != nil {
+		channel.Spec.ConfigMapRef.Namespace = channel.Namespace
+	}
+
+	if channel.Spec.SecretRef != nil {
+		channel.Spec.SecretRef.Namespace = channel.Namespace
 	}
 
 	err = client.Get(context.TODO(),

--- a/pkg/utils/helmrepo_test.go
+++ b/pkg/utils/helmrepo_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
 	"helm.sh/helm/v3/pkg/repo"
+	corev1 "k8s.io/api/core/v1"
 	clientsetx "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,6 +99,46 @@ func TestGenerateHelmIndexFile(t *testing.T) {
 	indexFile, err := GenerateHelmIndexFile(githubsub, "../..", chartDirs)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(len(indexFile.Entries)).To(gomega.Equal(2))
+}
+
+func TestConfigMapSecretRefsInHelmRelease(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c = mgr.GetClient()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	chartDirs := make(map[string]string)
+	chartDirs["../../test/github/helmcharts/chart1/"] = "../../test/github/helmcharts/chart1/"
+	chartDirs["../../test/github/helmcharts/chart2/"] = "../../test/github/helmcharts/chart2/"
+
+	indexFile, err := GenerateHelmIndexFile(githubsub, "../..", chartDirs)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(len(indexFile.Entries)).To(gomega.Equal(2))
+
+	time.Sleep(3 * time.Second)
+
+	githubchnNew := githubchn.DeepCopy()
+
+	githubchnNew.Spec.ConfigMapRef = &corev1.ObjectReference{Name: "channel-configmap"}
+	githubchnNew.Spec.SecretRef = &corev1.ObjectReference{Name: "channel-secret"}
+
+	githubsub.UID = "dummyuid"
+	helmrelease, err := CreateOrUpdateHelmChart("chart1", "chart1-1.0.0", indexFile.Entries["chart1"], c, githubchnNew, nil, githubsub)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(helmrelease).NotTo(gomega.BeNil())
+
+	g.Expect(helmrelease.Repo.ConfigMapRef.Namespace).To(gomega.Equal(githubchnNew.Namespace))
+	g.Expect(helmrelease.Repo.SecretRef.Namespace).To(gomega.Equal(githubchnNew.Namespace))
 }
 
 func TestCreateOrUpdateHelmChart(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/16521


A channel has configmap and secret refs without their namespaces like this.

```
spec:
  pathname: https://raw.githubusercontent.com/open-cluster-management/app-ui-e2e-private-helm/main
  secretRef:
    name: hcom-open-cluster-management-app-ui-e2e-private-helm-main-auth
  type: HelmRepo
```

The subscription-release controller assumes the secret and confiigmap are in subscription namespace. Subscription controller needs to set the channel namespace in creating helmrelease resource.