### PR TITLE
generously handle long application subscription name

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -599,7 +599,8 @@ func (r *ReconcileSubscription) createDeployable(
 	dplLabels := make(map[string]string)
 	dplLabels[chnv1.KeyChannel] = chn.Name
 	dplLabels[chnv1.KeyChannelType] = string(chn.Spec.Type)
-	dplLabels[appv1.LabelSubscriptionName] = subscriptionNameLabelStr
+	// subscription name can be longer than 63 characters because it is applicationName + -subscription-n. A label cannot exceed 63 chars.
+	dplLabels[appv1.LabelSubscriptionName] = utils.TrimLabelLast63Chars(subscriptionNameLabelStr)
 	dpl.SetLabels(dplLabels)
 
 	dpl.Spec.Template = &runtime.RawExtension{}

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -718,7 +718,9 @@ func (r *ReconcileSubscription) prepareDeployableForSubscription(sub, rootSub *a
 			APIVersion: "apps.open-cluster-management.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sub.Name + "-deployable",
+			// deployable name can be longer than 63 characters because it is applicationName + -subscription-n-deployable.
+			// Deployable name is used by deployable controller to create a label.
+			Name:      utils.TrimLabelLast63Chars(sub.Name + "-deployable"),
 			Namespace: sub.Namespace,
 			Labels: map[string]string{
 				dplv1alpha1.LabelSubscriptionPause: labelPause,
@@ -1046,7 +1048,8 @@ func (r *ReconcileSubscription) getSubscriptionDeployables(sub *appv1alpha1.Subs
 			}
 			subscriptionNameLabelStr := strings.ReplaceAll(subscriptionNameLabel.String(), "/", "-")
 
-			subLabel[appv1alpha1.LabelSubscriptionName] = subscriptionNameLabelStr
+			// subscription name can be longer than 63 characters because it is applicationName + -subscription-n. A label cannot exceed 63 chars.
+			subLabel[appv1alpha1.LabelSubscriptionName] = utils.TrimLabelLast63Chars(subscriptionNameLabelStr)
 		}
 
 		labelSelector := &metav1.LabelSelector{

--- a/pkg/subscriber/namespace/deployable_subscriber_test.go
+++ b/pkg/subscriber/namespace/deployable_subscriber_test.go
@@ -102,15 +102,6 @@ var (
 	}
 )
 
-var (
-	chns = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      id.Namespace,
-			Namespace: id.Namespace,
-		},
-	}
-)
-
 var _ = Describe("default deployable should be reconciled", func() {
 	It("should reconcile on deployable add/update/delete event", func() {
 		// prepare default channel

--- a/pkg/subscriber/namespace/deployable_subscriber_test.go
+++ b/pkg/subscriber/namespace/deployable_subscriber_test.go
@@ -114,7 +114,6 @@ var (
 var _ = Describe("default deployable should be reconciled", func() {
 	It("should reconcile on deployable add/update/delete event", func() {
 		// prepare default channel
-		ns := chns.DeepCopy()
 		dpl := chdpl.DeepCopy()
 		dpldft := defaultchdpl.DeepCopy()
 		// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
@@ -139,9 +138,5 @@ var _ = Describe("default deployable should be reconciled", func() {
 		time.Sleep(k8swait)
 		Expect(k8sClient.Get(context.TODO(), workloadkey, cfgmap)).To(HaveOccurred())
 		Expect(k8sClient.Get(context.TODO(), defaultworkloadkey, cfgmap)).To(HaveOccurred())
-
-		defer func() {
-			Expect(k8sClient.Delete(context.TODO(), ns)).Should(Succeed())
-		}()
 	})
 })

--- a/pkg/utils/label.go
+++ b/pkg/utils/label.go
@@ -96,3 +96,12 @@ func ValidateK8sLabel(s string) string {
 
 	return s[start:stop]
 }
+
+// TrimLabelLast63Chars returns the last 63 characters of the input string
+func TrimLabelLast63Chars(s string) string {
+	if len(s) > 63 {
+		s = s[len(s)-63:]
+	}
+
+	return s
+}


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/14270

When a long application name is used, UI generates a long subscription name and the controller generates a long subscription deployable name like `default-cloud-provider-quota-check-cloud-provider-quota-check-subscription-1-deployable`. These long names are used as labels in appsub and deployable causing 

```status:
  lastUpdateTime: "2021-07-13T21:02:48Z"
  phase: PropagationFailed
  reason: 'Deployable.apps.open-cluster-management.io "cloud-provider-quota-check-cloud-provider-quota-check-subscription-1-seeds-hub-apps-cloud-provider-quota-check-cloudprovider-quotacheck-serviceaccount" is invalid: metadata.labels: Invalid value: "default-cloud-provider-quota-check-cloud-provider-quota-check-subscription-1": must be no more than 63 characters/n'
```