### PR TITLE
fix long deployable name

### DIFF
--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -600,7 +600,7 @@ func (r *ReconcileSubscription) createDeployable(
 	dplLabels[chnv1.KeyChannel] = chn.Name
 	dplLabels[chnv1.KeyChannelType] = string(chn.Spec.Type)
 	// subscription name can be longer than 63 characters because it is applicationName + -subscription-n. A label cannot exceed 63 chars.
-	dplLabels[appv1.LabelSubscriptionName] = utils.TrimLabelLast63Chars(subscriptionNameLabelStr)
+	dplLabels[appv1.LabelSubscriptionName] = utils.ValidateK8sLabel(utils.TrimLabelLast63Chars(subscriptionNameLabelStr))
 	dpl.SetLabels(dplLabels)
 
 	dpl.Spec.Template = &runtime.RawExtension{}

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -720,7 +720,7 @@ func (r *ReconcileSubscription) prepareDeployableForSubscription(sub, rootSub *a
 		ObjectMeta: metav1.ObjectMeta{
 			// deployable name can be longer than 63 characters because it is applicationName + -subscription-n-deployable.
 			// Deployable name is used by deployable controller to create a label.
-			Name:      utils.TrimLabelLast63Chars(sub.Name + "-deployable"),
+			Name:      utils.ValidateK8sLabel(utils.TrimLabelLast63Chars(sub.Name + "-deployable")),
 			Namespace: sub.Namespace,
 			Labels: map[string]string{
 				dplv1alpha1.LabelSubscriptionPause: labelPause,
@@ -1049,7 +1049,7 @@ func (r *ReconcileSubscription) getSubscriptionDeployables(sub *appv1alpha1.Subs
 			subscriptionNameLabelStr := strings.ReplaceAll(subscriptionNameLabel.String(), "/", "-")
 
 			// subscription name can be longer than 63 characters because it is applicationName + -subscription-n. A label cannot exceed 63 chars.
-			subLabel[appv1alpha1.LabelSubscriptionName] = utils.TrimLabelLast63Chars(subscriptionNameLabelStr)
+			subLabel[appv1alpha1.LabelSubscriptionName] = utils.ValidateK8sLabel(utils.TrimLabelLast63Chars(subscriptionNameLabelStr))
 		}
 
 		labelSelector := &metav1.LabelSelector{

--- a/pkg/controller/mcmhub/hub_test.go
+++ b/pkg/controller/mcmhub/hub_test.go
@@ -194,7 +194,8 @@ func TestPrepareDeployableForSubscription(t *testing.T) {
 	g.Expect(subDpl).NotTo(gomega.BeNil())
 	// subscription deployable name cannot exceed 63 charaters because it will be used as a label
 	// by deployable controller. A label cannot exceed 63 charaters
-	g.Expect(len(subDpl.Name)).To(gomega.Equal(63))
+	// 63 but the leading - character gets removed to be a valid k8s name
+	g.Expect(len(subDpl.Name)).To(gomega.Equal(62))
 }
 
 func TestUpdateSubscriptionToTarget(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/open-cluster-management/backlog/issues/14270

Make sure shortened deployable name is a valid k8s name.