### PR TITLE
Use a better semver library to handle version parsing to deal with version that starts with a character v

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/open-cluster-management/multicloud-operators-subscription
 go 1.17
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go-v2 v1.3.2
 	github.com/aws/aws-sdk-go-v2/config v1.1.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.5.0
@@ -46,7 +47,6 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Masterminds/squirrel v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/blang/semver"
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/ghodss/yaml"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/repo"
@@ -558,7 +558,7 @@ func removeNoMatchingName(sub *appv1.Subscription, indexFile *repo.IndexFile) er
 }
 
 //filterOnVersion filters the indexFile with the version, and Digest provided in the subscription
-//The version provided in the subscription can be an expression like ">=1.2.3" (see https://github.com/blang/semver)
+//The version provided in the subscription can be an expression like ">=1.2.3" (see github.com/Masterminds/semver)
 func filterOnVersion(sub *appv1.Subscription, indexFile *repo.IndexFile) {
 	keys := make([]string, 0)
 	for k := range indexFile.Entries {
@@ -600,21 +600,21 @@ func checkVersion(sub *appv1.Subscription, chartVersion *repo.ChartVersion) bool
 	if sub.Spec.PackageFilter != nil {
 		if sub.Spec.PackageFilter.Version != "" {
 			version := chartVersion.Version
-			versionVersion, err := semver.Parse(version)
+			versionVersion, err := semver.NewVersion(version)
 
 			if err != nil {
 				klog.Error(err)
 				return false
 			}
 
-			filterVersion, err := semver.ParseRange(sub.Spec.PackageFilter.Version)
+			filterVersion, err := semver.NewConstraint(sub.Spec.PackageFilter.Version)
 
 			if err != nil {
 				klog.Error(err)
 				return false
 			}
 
-			return filterVersion(versionVersion)
+			return filterVersion.Check(versionVersion)
 		}
 	}
 

--- a/pkg/utils/helmrepo_test.go
+++ b/pkg/utils/helmrepo_test.go
@@ -263,6 +263,20 @@ func TestCheckVersion(t *testing.T) {
 
 	ret = checkVersion(githubsub, chartVersion)
 	g.Expect(ret).To(gomega.BeTrue())
+
+	packageFilter = &appv1alpha1.PackageFilter{}
+	packageFilter.Version = "v2.0.0"
+
+	githubsub.Spec.PackageFilter = packageFilter
+
+	ret = checkVersion(githubsub, chartVersion)
+	g.Expect(ret).To(gomega.BeFalse())
+
+	packageFilter = &appv1alpha1.PackageFilter{}
+	githubsub.Spec.PackageFilter = packageFilter
+
+	ret = checkVersion(githubsub, chartVersion)
+	g.Expect(ret).To(gomega.BeTrue())
 }
 
 func TestOverride(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

for https://github.com/open-cluster-management/backlog/issues/18287

/hold

Do not merge until 2.4.1 is done.