### PR TITLE
Fix subscription spec changes not triggering Helm appsub updates

### DIFF
--- a/pkg/controller/mcmhub/hook_test.go
+++ b/pkg/controller/mcmhub/hook_test.go
@@ -288,7 +288,7 @@ var _ = Describe("given a subscription pointing to a git path without hook folde
 				Name:      subKey.Name,
 				Namespace: subKey.Namespace,
 				Annotations: map[string]string{
-					subv1.AnnotationGitBranch: "release-2.0",
+					subv1.AnnotationGitBranch: "main",
 					subv1.AnnotationGitPath:   "test/github/resources",
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

As discussed, if the subscription came from MCH resource then the logic is the same as before.
Otherwise, proceed with the helm subscription processing. 

For https://github.com/open-cluster-management/backlog/issues/18183 and https://github.com/open-cluster-management/backlog/issues/17840