### PR TITLE
ACM-30168 Add cluster TLS profile and use it for managers and webhook

### DIFF
--- a/cmd/appsubsummary/exec/manager.go
+++ b/cmd/appsubsummary/exec/manager.go
@@ -15,24 +15,28 @@
 package exec
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"os"
 
+	ocinfrav1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
-	appsubapi "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
-	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
-	managedClusterView "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
-	"open-cluster-management.io/multicloud-operators-subscription/pkg/controller"
-	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	appsubapi "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
+	managedClusterView "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/controller"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils/tlsconfig"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -70,6 +74,10 @@ func RunManager() {
 		}
 	}
 
+	schemeForTLS := runtime.NewScheme()
+	_ = ocinfrav1.AddToScheme(schemeForTLS)
+	tlsconfig.InitClusterTLSConfig(context.Background(), cfg, schemeForTLS)
+
 	klog.Info("Leader election settings",
 		"leaseDuration", options.LeaderElectionLeaseDuration,
 		"renewDeadline", options.LeaderElectionRenewDeadline,
@@ -77,7 +85,9 @@ func RunManager() {
 
 	webhookOption := k8swebhook.Options{}
 	webhookOption.TLSOpts = append(webhookOption.TLSOpts, func(config *tls.Config) {
-		config.MinVersion = appsubv1.TLSMinVersionInt
+		c := tlsconfig.GetClusterTLSConfig()
+		config.MinVersion = c.MinVersion
+		config.CipherSuites = c.CipherSuites
 	})
 	webhookServer := k8swebhook.NewServer(webhookOption)
 

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -46,12 +47,12 @@ import (
 	agentaddon "open-cluster-management.io/multicloud-operators-subscription/addon"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	ansiblejob "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/ansible/v1alpha1"
-	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/controller"
 	leasectrl "open-cluster-management.io/multicloud-operators-subscription/pkg/controller/subscription"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/subscriber"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/synchronizer"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils/tlsconfig"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/webhook"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -115,6 +116,11 @@ func RunManager() {
 	cfg.QPS = 100.0
 	cfg.Burst = 200
 
+	// Cache cluster TLS profile (API Server) for use by webhook, health server, and listeners.
+	schemeForTLS := runtime.NewScheme()
+	_ = ocinfrav1.AddToScheme(schemeForTLS)
+	tlsconfig.InitClusterTLSConfig(context.Background(), cfg, schemeForTLS)
+
 	klog.Info("Leader election settings",
 		"leaseDuration", Options.LeaderElectionLeaseDuration,
 		"renewDeadline", Options.LeaderElectionRenewDeadline,
@@ -122,7 +128,9 @@ func RunManager() {
 
 	webhookOption := k8swebhook.Options{}
 	webhookOption.TLSOpts = append(webhookOption.TLSOpts, func(config *tls.Config) {
-		config.MinVersion = appsubv1.TLSMinVersionInt
+		c := tlsconfig.GetClusterTLSConfig()
+		config.MinVersion = c.MinVersion
+		config.CipherSuites = c.CipherSuites
 	})
 	webhookServer := k8swebhook.NewServer(webhookOption)
 
@@ -397,9 +405,7 @@ func serveHealthProbes(healthProbeBindAddress string, configCheck healthz.Checke
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 		Addr:              healthProbeBindAddress,
-		TLSConfig: &tls.Config{
-			MinVersion: appsubv1.TLSMinVersionInt, // #nosec G402 -- TLS 1.2 is required for FIPS
-		},
+		TLSConfig:         tlsconfig.GetClusterTLSConfig(),
 	}
 
 	klog.Infof("heath probes server is running...")

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -15,17 +15,14 @@
 package exec
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"os"
 
+	ocinfrav1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	"open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
-	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
-	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/controller"
-	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/utils"
-	appsubutils "open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
-
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,6 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/controller"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/utils"
+	appsubutils "open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils/tlsconfig"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -75,6 +78,10 @@ func RunManager() {
 	cfg.QPS = 30.0
 	cfg.Burst = 60
 
+	schemeForTLS := runtime.NewScheme()
+	_ = ocinfrav1.AddToScheme(schemeForTLS)
+	tlsconfig.InitClusterTLSConfig(context.Background(), cfg, schemeForTLS)
+
 	klog.Info("Leader election settings",
 		"leaseDuration", options.LeaderElectionLeaseDuration,
 		"renewDeadline", options.LeaderElectionRenewDeadline,
@@ -82,7 +89,9 @@ func RunManager() {
 
 	webhookOption := k8swebhook.Options{}
 	webhookOption.TLSOpts = append(webhookOption.TLSOpts, func(config *tls.Config) {
-		config.MinVersion = appsubv1.TLSMinVersionInt
+		c := tlsconfig.GetClusterTLSConfig()
+		config.MinVersion = c.MinVersion
+		config.CipherSuites = c.CipherSuites
 	})
 	webhookServer := k8swebhook.NewServer(webhookOption)
 

--- a/pkg/utils/tlsconfig/tlsconfig.go
+++ b/pkg/utils/tlsconfig/tlsconfig.go
@@ -52,6 +52,7 @@ func InitClusterTLSConfig(ctx context.Context, cfg *rest.Config, scheme *runtime
 		if cfg != nil && scheme != nil {
 			cachedTLSConfig = fetchTLSConfigFromCluster(ctx, cfg, scheme)
 		}
+
 		if cachedTLSConfig == nil {
 			cachedTLSConfig = profileSpecToTLSConfig(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
 		}
@@ -65,6 +66,7 @@ func GetClusterTLSConfig() *tls.Config {
 	if cachedTLSConfig != nil {
 		return cachedTLSConfig
 	}
+
 	return profileSpecToTLSConfig(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
 }
 
@@ -75,17 +77,22 @@ func fetchTLSConfigFromCluster(ctx context.Context, cfg *rest.Config, scheme *ru
 	if err != nil {
 		return nil
 	}
+
 	var apiServer configv1.APIServer
 	if err := kubeClient.Get(ctx, types.NamespacedName{Name: apiserverClusterName}, &apiServer); err != nil {
 		return nil
 	}
+
 	spec := getEffectiveProfileSpec(apiServer.Spec.TLSSecurityProfile)
+
 	profileType := configv1.TLSProfileIntermediateType
 	if p := apiServer.Spec.TLSSecurityProfile; p != nil {
 		profileType = p.Type
 	}
+
 	klog.Infof("TLS security profile used: profileType=%s minTLSVersion=%s cipherSuiteCount=%d",
 		profileType, spec.MinTLSVersion, len(spec.Ciphers))
+
 	return profileSpecToTLSConfig(spec)
 }
 
@@ -95,12 +102,15 @@ func getEffectiveProfileSpec(profile *configv1.TLSSecurityProfile) *configv1.TLS
 	if profile == nil {
 		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 	}
+
 	if profile.Type == configv1.TLSProfileCustomType && profile.Custom != nil {
 		return &profile.Custom.TLSProfileSpec
 	}
+
 	if spec := configv1.TLSProfiles[profile.Type]; spec != nil {
 		return spec
 	}
+
 	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 }
 
@@ -117,5 +127,6 @@ func profileSpecToTLSConfig(spec *configv1.TLSProfileSpec) *tls.Config {
 		MinVersion:   minVersion,
 		CipherSuites: cipherIDs,
 	}
+
 	return crypto.SecureTLSConfig(config)
 }

--- a/pkg/utils/tlsconfig/tlsconfig.go
+++ b/pkg/utils/tlsconfig/tlsconfig.go
@@ -1,0 +1,121 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tlsconfig builds TLS configuration from the OpenShift cluster's API Server.
+//
+// Usage:
+//  1. At process startup (in main), call InitClusterTLSConfig(ctx, restConfig, scheme).
+//     The scheme must have configv1.AddToScheme(scheme) called first.
+//  2. Wherever you need a *tls.Config (servers or clients), call GetClusterTLSConfig().
+//
+// If the cluster is not OpenShift or the APIServer resource is missing, the default
+// (Intermediate profile: TLS 1.2 min, safe ciphers) is used.
+package tlsconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"sync"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cachedTLSConfig *tls.Config
+	initOnce        sync.Once
+)
+
+const apiserverClusterName = "cluster"
+
+// InitClusterTLSConfig loads the cluster's TLS profile once and caches it.
+// Call this at startup (e.g. in each cmd's RunManager) after you have rest.Config.
+// Later calls do nothing. Scheme must include OpenShift config types (configv1.AddToScheme).
+func InitClusterTLSConfig(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme) {
+	initOnce.Do(func() {
+		if cfg != nil && scheme != nil {
+			cachedTLSConfig = fetchTLSConfigFromCluster(ctx, cfg, scheme)
+		}
+		if cachedTLSConfig == nil {
+			cachedTLSConfig = profileSpecToTLSConfig(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+		}
+	})
+}
+
+// GetClusterTLSConfig returns the cached TLS config for the process.
+// Use this for http.Server.TLSConfig, http.Transport.TLSClientConfig, webhook TLSOpts, etc.
+// If InitClusterTLSConfig was never called, returns the default (Intermediate) profile.
+func GetClusterTLSConfig() *tls.Config {
+	if cachedTLSConfig != nil {
+		return cachedTLSConfig
+	}
+	return profileSpecToTLSConfig(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+}
+
+// fetchTLSConfigFromCluster reads the APIServer "cluster" resource and converts its
+// tlsSecurityProfile into a *tls.Config. Returns nil on any error (e.g. not OpenShift, NotFound).
+func fetchTLSConfigFromCluster(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme) *tls.Config {
+	kubeClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil
+	}
+	var apiServer configv1.APIServer
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: apiserverClusterName}, &apiServer); err != nil {
+		return nil
+	}
+	spec := getEffectiveProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	profileType := configv1.TLSProfileIntermediateType
+	if p := apiServer.Spec.TLSSecurityProfile; p != nil {
+		profileType = p.Type
+	}
+	klog.Infof("TLS security profile used: profileType=%s minTLSVersion=%s cipherSuiteCount=%d",
+		profileType, spec.MinTLSVersion, len(spec.Ciphers))
+	return profileSpecToTLSConfig(spec)
+}
+
+// getEffectiveProfileSpec turns a TLSSecurityProfile (Old/Intermediate/Modern/Custom)
+// into a concrete TLSProfileSpec (min version + cipher list). Nil or unknown → Intermediate.
+func getEffectiveProfileSpec(profile *configv1.TLSSecurityProfile) *configv1.TLSProfileSpec {
+	if profile == nil {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+	if profile.Type == configv1.TLSProfileCustomType && profile.Custom != nil {
+		return &profile.Custom.TLSProfileSpec
+	}
+	if spec := configv1.TLSProfiles[profile.Type]; spec != nil {
+		return spec
+	}
+	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+}
+
+// profileSpecToTLSConfig converts a TLSProfileSpec (min version + ciphers) into Go's *tls.Config.
+// OpenShift uses OpenSSL-style cipher names; we convert to IANA then to Go constants.
+func profileSpecToTLSConfig(spec *configv1.TLSProfileSpec) *tls.Config {
+	if spec == nil {
+		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+	minVersion := crypto.TLSVersionOrDie(string(spec.MinTLSVersion))
+	ianaCiphers := crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+	cipherIDs := crypto.CipherSuitesOrDie(ianaCiphers)
+	config := &tls.Config{
+		MinVersion:   minVersion,
+		CipherSuites: cipherIDs,
+	}
+	return crypto.SecureTLSConfig(config)
+}

--- a/pkg/webhook/listener/webhook_listener.go
+++ b/pkg/webhook/listener/webhook_listener.go
@@ -16,7 +16,6 @@ package listener
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -40,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils/tlsconfig"
 
 	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
@@ -115,9 +115,7 @@ func (listener *WebhookListener) Start(ctx context.Context) error {
 			Addr:              ":8443",
 			Handler:           mux,
 			ReadHeaderTimeout: 32 * time.Second,
-			TLSConfig: &tls.Config{
-				MinVersion: appv1alpha1.TLSMinVersionInt, // #nosec G402 -- TLS 1.2 is required for FIPS
-			},
+			TLSConfig:         tlsconfig.GetClusterTLSConfig(),
 		}
 
 		klog.Fatal(s.ListenAndServeTLS(listener.TLSCrtFile, listener.TLSKeyFile))


### PR DESCRIPTION
Jira ticket: https://redhat.atlassian.net/browse/ACM-30168

Introduce pkg/utils/tlsconfig to read the OpenShift cluster APIServer tlsSecurityProfile and cache a matching crypto/tls.Config for the process. Initialize that config at startup in the subscription, appsubsummary, and placementrule managers, and wire the webhook listener to use GetClusterTLSConfig(). If the APIServer resource is missing or the cluster is not OpenShift, fall back to the Intermediate TLS profile. Log profile type, MinTLSVersion, and cipher suite count after reading APIServer.

* [ ] I have taken backward compatibility into consideration.
