### PR TITLE
prevent concurrent execution of doSubscription when it is restared by…

### DIFF
--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -72,6 +73,7 @@ type SubscriberItem struct {
 	desiredTag             string
 	syncTime               string
 	stopch                 chan struct{}
+	wg                     sync.WaitGroup
 	syncinterval           int
 	count                  int
 	synchronizer           SyncSource
@@ -92,12 +94,16 @@ type kubeResource struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
-// Start subscribes a subscriber item with github channel
+// Start subscribes a subscriber item with github channel.
+// When restart is true, Stop is called first which blocks until the current
+// doSubscription goroutine finishes, ensuring no two goroutines race on
+// shared SubscriberItem fields.
 func (ghsi *SubscriberItem) Start(restart bool) {
 	// do nothing if already started
 	if ghsi.stopch != nil {
 		if restart {
-			// restart this goroutine
+			// Stop blocks until the running goroutine has fully exited before
+			// we create a new one, preventing concurrent access to shared state.
 			klog.Info("Stopping SubscriberItem: ", ghsi.Subscription.Name)
 			ghsi.Stop()
 		} else {
@@ -120,34 +126,49 @@ func (ghsi *SubscriberItem) Start(restart bool) {
 		return
 	}
 
-	go wait.Until(func() {
-		tw := ghsi.SubscriberItem.Subscription.Spec.TimeWindow
-		if tw != nil {
-			nextRun := utils.NextStartPoint(tw, time.Now())
-			if nextRun > time.Duration(0) {
-				klog.Infof("Subscription is currently blocked by the time window. It %v/%v will be deployed after %v",
-					ghsi.SubscriberItem.Subscription.GetNamespace(),
-					ghsi.SubscriberItem.Subscription.GetName(), nextRun)
+	ghsi.wg.Add(1)
+
+	go func() {
+		defer ghsi.wg.Done()
+
+		wait.Until(func() {
+			tw := ghsi.SubscriberItem.Subscription.Spec.TimeWindow
+			if tw != nil {
+				nextRun := utils.NextStartPoint(tw, time.Now())
+				if nextRun > time.Duration(0) {
+					klog.Infof("Subscription is currently blocked by the time window. It %v/%v will be deployed after %v",
+						ghsi.SubscriberItem.Subscription.GetNamespace(),
+						ghsi.SubscriberItem.Subscription.GetName(), nextRun)
+
+					return
+				}
+			}
+
+			// if the subscription pause lable is true, stop subscription here.
+			if utils.GetPauseLabel(ghsi.SubscriberItem.Subscription) {
+				klog.Infof("Git Subscription %v/%v is paused.", ghsi.SubscriberItem.Subscription.GetNamespace(), ghsi.SubscriberItem.Subscription.GetName())
 
 				return
 			}
-		}
 
-		// if the subscription pause lable is true, stop subscription here.
-		if utils.GetPauseLabel(ghsi.SubscriberItem.Subscription) {
-			klog.Infof("Git Subscription %v/%v is paused.", ghsi.SubscriberItem.Subscription.GetNamespace(), ghsi.SubscriberItem.Subscription.GetName())
-
-			return
-		}
-
-		ghsi.doSubscriptionWithRetries(retryInterval, retries)
-	}, loopPeriod, ghsi.stopch)
+			ghsi.doSubscriptionWithRetries(retryInterval, retries)
+		}, loopPeriod, ghsi.stopch)
+	}()
 }
 
-// Stop unsubscribes a subscriber item with namespace channel
+// Stop unsubscribes a subscriber item with namespace channel and waits for the
+// current doSubscription goroutine to finish before returning. This prevents a
+// concurrent new goroutine (started by the next Start call) from racing on
+// shared SubscriberItem fields such as ghsi.resources.
 func (ghsi *SubscriberItem) Stop() {
 	klog.Info("Stopping SubscriberItem ", ghsi.Subscription.Name)
-	close(ghsi.stopch)
+
+	if ghsi.stopch != nil {
+		close(ghsi.stopch)
+		ghsi.stopch = nil
+	}
+
+	ghsi.wg.Wait()
 }
 
 func (ghsi *SubscriberItem) doSubscriptionWithRetries(retryInterval time.Duration, retries int) {
@@ -183,6 +204,11 @@ func (ghsi *SubscriberItem) doSubscription() error {
 	klog.Info("enter doSubscription: ", hostkey.String())
 
 	defer klog.Info("exit doSubscription: ", hostkey.String())
+
+	// Reset successful so that an empty resource list from a previous run cannot
+	// bypass the guard at the bottom of this function and trigger a spurious
+	// PurgeAllSubscribedResources call.
+	ghsi.successful = false
 
 	utils.UpdateLastUpdateTime(ghsi.synchronizer.GetLocalClient(), ghsi.Subscription)
 

--- a/pkg/subscriber/git/git_subscriber_item_lifecycle_test.go
+++ b/pkg/subscriber/git/git_subscriber_item_lifecycle_test.go
@@ -1,0 +1,321 @@
+// Copyright 2024 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+// Tests for the goroutine lifecycle fix in git_subscriber_item.go.
+//
+// These tests cover three categories:
+//  1. Stop() nil-safety / idempotency (no k8s required).
+//  2. WaitGroup semantics – Stop() must block until the running goroutine
+//     exits, ensuring no two goroutines ever race on shared SubscriberItem
+//     fields (ghsi.resources, ghsi.successful, etc.).
+//  3. doSubscription() resets ghsi.successful to false at entry so that a
+//     stale "true" value left by a previous run cannot bypass the empty-
+//     resource guard and trigger a spurious PurgeAllSubscribedResources call.
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
+	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+	kubesynchronizer "open-cluster-management.io/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// noopSyncSource satisfies the SyncSource interface. GetLocalClient returns a
+// fake controller-runtime client that returns NotFound for all Gets; this lets
+// utils.UpdateLastUpdateTime (and similar helpers) fail gracefully without
+// needing a real API server.
+type noopSyncSource struct {
+	fakeClient client.Client
+}
+
+func newNoopSyncSource() *noopSyncSource {
+	return &noopSyncSource{
+		// Build a fake client using the default scheme. Custom types such as
+		// appv1.Subscription are not registered, so Gets on them return a "no
+		// kind is registered" error – which callers already handle gracefully.
+		fakeClient: fake.NewClientBuilder().Build(),
+	}
+}
+
+func (n *noopSyncSource) GetInterval() int                                       { return 0 }
+func (n *noopSyncSource) GetLocalClient() client.Client                          { return n.fakeClient }
+func (n *noopSyncSource) GetLocalNonCachedClient() client.Client                 { return n.fakeClient }
+func (n *noopSyncSource) GetRemoteClient() client.Client                         { return nil }
+func (n *noopSyncSource) GetRemoteNonCachedClient() client.Client                { return nil }
+func (n *noopSyncSource) IsResourceNamespaced(_ *unstructured.Unstructured) bool { return true }
+func (n *noopSyncSource) ProcessSubResources(_ *appv1.Subscription,
+	_ []kubesynchronizer.ResourceUnit,
+	_, _ map[string]map[string]string,
+	_, _ bool) error {
+	return nil
+}
+func (n *noopSyncSource) PurgeAllSubscribedResources(_ *appv1.Subscription) error { return nil }
+func (n *noopSyncSource) UpdateAppsubOverallStatus(_ *appv1.Subscription, _ bool, _ string) error {
+	return nil
+}
+
+// minimalItem constructs a SubscriberItem with just enough state for
+// doSubscription to start executing: a Subscription, a Channel with an
+// intentionally unreachable URL (so cloneGitRepo fails fast without a
+// network timeout), and a noop synchronizer.
+func minimalItem() *SubscriberItem {
+	return &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lifecycle-test-sub",
+					Namespace: "default",
+				},
+			},
+			// Use localhost:1 so that the git clone attempt fails
+			// immediately (connection refused) rather than timing out.
+			Channel: &chnv1.Channel{
+				Spec: chnv1.ChannelSpec{
+					Pathname: "https://localhost:1/nonexistent.git",
+				},
+			},
+		},
+		synchronizer: newNoopSyncSource(),
+	}
+}
+
+// ─── Stop() nil-safety ────────────────────────────────────────────────────────
+
+// TestStop_NilStopch verifies that Stop() on a zero-value SubscriberItem
+// (where stopch is nil and no goroutine has ever been started) does not panic.
+func TestStop_NilStopch(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop() panicked on nil stopch: %v", r)
+		}
+	}()
+
+	item := &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "s"},
+			},
+		},
+	}
+	item.Stop() // must not panic
+}
+
+// TestStop_Idempotent verifies that calling Stop() twice does not cause a
+// double-close panic. The nil-guard on stopch must make the second call a no-op.
+func TestStop_Idempotent(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Stop() panicked: %v", r)
+		}
+	}()
+
+	item := &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "s"},
+			},
+		},
+	}
+	item.stopch = make(chan struct{})
+
+	item.Stop() // first call: closes stopch, sets stopch = nil
+	item.Stop() // second call: stopch is nil, must be a no-op
+}
+
+// TestStop_NilsStopchAfterReturn verifies the nil-guard postcondition: after
+// Stop() returns, ghsi.stopch must be nil so that a subsequent Start() can
+// create a fresh channel without risk of closing an already-closed one.
+func TestStop_NilsStopchAfterReturn(t *testing.T) {
+	item := &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "s"},
+			},
+		},
+	}
+	item.stopch = make(chan struct{})
+	item.Stop()
+
+	if item.stopch != nil {
+		t.Fatal("expected stopch to be nil after Stop()")
+	}
+}
+
+// ─── WaitGroup semantics ──────────────────────────────────────────────────────
+
+// TestStop_WaitsForRunningGoroutine is the central test for the race-condition
+// fix. It manually registers a goroutine under the SubscriberItem's WaitGroup
+// (exactly as Start() does) and verifies that Stop() blocks until that
+// goroutine exits before returning.
+//
+// Without the wg.Wait() call in Stop(), this test would fail: Stop() would
+// return while the goroutine was still running, allowing a subsequent goroutine
+// to race on shared SubscriberItem fields.
+func TestStop_WaitsForRunningGoroutine(t *testing.T) {
+	item := &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "s"},
+			},
+		},
+	}
+	item.stopch = make(chan struct{})
+
+	goroutineStarted := make(chan struct{})
+	goroutineCanExit := make(chan struct{})
+
+	// Simulate a running goroutine, exactly as Start() sets up.
+	item.wg.Add(1)
+
+	go func() {
+		defer item.wg.Done()
+
+		close(goroutineStarted)
+		<-goroutineCanExit // hold until the test releases it
+	}()
+
+	<-goroutineStarted // ensure the goroutine is running before calling Stop()
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		item.Stop()
+		close(stopReturned)
+	}()
+
+	// Stop() should be blocked while the goroutine is still running.
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before the goroutine exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Allow the goroutine to finish.
+	close(goroutineCanExit)
+
+	// Stop() must unblock promptly once the goroutine exits.
+	select {
+	case <-stopReturned:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after the goroutine exited")
+	}
+}
+
+// TestStart_RestartSerializesGoroutines verifies the end-to-end invariant that
+// motivates the fix: when Start(restart=true) is called while a goroutine is
+// already running (represented by an entry in the WaitGroup), the call blocks
+// via Stop() until the old goroutine finishes before the new one is allowed to
+// start, preventing two goroutines from concurrently touching ghsi.resources.
+func TestStart_RestartSerializesGoroutines(t *testing.T) {
+	item := &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "s"},
+			},
+		},
+	}
+	item.stopch = make(chan struct{})
+
+	firstGoroutineStarted := make(chan struct{})
+	firstGoroutineCanExit := make(chan struct{})
+	firstGoroutineExited := make(chan struct{})
+
+	// Simulate the first "running" goroutine.
+	item.wg.Add(1)
+
+	go func() {
+		defer item.wg.Done()
+		defer close(firstGoroutineExited)
+
+		close(firstGoroutineStarted)
+		<-firstGoroutineCanExit
+	}()
+
+	<-firstGoroutineStarted
+
+	// Invoke Stop() (the part of Start(restart=true) that serializes goroutines)
+	// in a separate goroutine so we can observe whether it blocks.
+	stopReturned := make(chan struct{})
+
+	go func() {
+		item.Stop() // must block until first goroutine exits
+		close(stopReturned)
+	}()
+
+	// Stop() should be blocked.
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before the first goroutine exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Release the first goroutine.
+	close(firstGoroutineCanExit)
+	<-firstGoroutineExited
+
+	// Now Stop() should complete.
+	select {
+	case <-stopReturned:
+		// success: new goroutines are safe to start because the old one has exited
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after the first goroutine exited")
+	}
+}
+
+// ─── doSubscription: successful field reset ───────────────────────────────────
+
+// The Ginkgo test below verifies the "successful" reset that guards against a
+// second, related facet of the race: a stale successful=true from a prior run
+// bypassing the empty-resource check and causing ProcessSubResources to be
+// called with no resources (which would trigger PurgeAllSubscribedResources).
+//
+// It relies on the webhookEnabled fast-path as a canary:
+//   - WITHOUT the fix: doSubscription would see successful=true right after the
+//     webhook check and return nil immediately (skip reconciliation).
+//   - WITH the fix: doSubscription resets successful=false first, so the webhook
+//     check falls through to cloneGitRepo, which fails (no real git server).
+//     doSubscription therefore returns a non-nil error.
+var _ = Describe("doSubscription resets successful flag", func() {
+	It("should reset successful=false at entry, preventing stale state from prior run", func() {
+		item := minimalItem()
+		item.synchronizer = defaultSubscriber.synchronizer
+
+		// Simulate a prior successful run leaving successful=true.
+		item.successful = true
+		item.webhookEnabled = true
+
+		// With the fix, doSubscription resets successful to false before the
+		// webhook check, so it does NOT return nil – it proceeds to cloneGitRepo
+		// (which fails), and returns a non-nil error.
+		err := item.doSubscription()
+		Expect(err).To(HaveOccurred(),
+			"doSubscription should have returned an error; "+
+				"a nil return would indicate it skipped via the stale successful=true path")
+		Expect(item.successful).To(BeFalse(),
+			"successful must be false after doSubscription fails")
+	})
+})

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	gerr "github.com/pkg/errors"
@@ -52,6 +53,7 @@ type SubscriberItem struct {
 	reconcileRate string
 	syncTime      string
 	stopch        chan struct{}
+	wg            sync.WaitGroup
 	count         int
 	syncinterval  int
 	success       bool
@@ -96,35 +98,47 @@ func (hrsi *SubscriberItem) Start(restart bool) {
 		return
 	}
 
-	go wait.Until(func() {
-		tw := hrsi.SubscriberItem.Subscription.Spec.TimeWindow
-		if tw != nil {
-			nextRun := utils.NextStartPoint(tw, time.Now())
-			if nextRun > time.Duration(0) {
-				klog.Infof("Subscription is currently blocked by the time window. It %v/%v will be deployed after %v",
-					hrsi.SubscriberItem.Subscription.GetNamespace(),
-					hrsi.SubscriberItem.Subscription.GetName(), nextRun)
+	hrsi.wg.Add(1)
+
+	go func() {
+		defer hrsi.wg.Done()
+
+		wait.Until(func() {
+			tw := hrsi.SubscriberItem.Subscription.Spec.TimeWindow
+			if tw != nil {
+				nextRun := utils.NextStartPoint(tw, time.Now())
+				if nextRun > time.Duration(0) {
+					klog.Infof("Subscription is currently blocked by the time window. It %v/%v will be deployed after %v",
+						hrsi.SubscriberItem.Subscription.GetNamespace(),
+						hrsi.SubscriberItem.Subscription.GetName(), nextRun)
+
+					return
+				}
+			}
+
+			// if the subscription pause lable is true, stop subscription here.
+			if utils.GetPauseLabel(hrsi.SubscriberItem.Subscription) {
+				klog.Infof("Helm Subscription %v/%v is paused.", hrsi.SubscriberItem.Subscription.GetNamespace(), hrsi.SubscriberItem.Subscription.GetName())
 
 				return
 			}
-		}
 
-		// if the subscription pause lable is true, stop subscription here.
-		if utils.GetPauseLabel(hrsi.SubscriberItem.Subscription) {
-			klog.Infof("Helm Subscription %v/%v is paused.", hrsi.SubscriberItem.Subscription.GetNamespace(), hrsi.SubscriberItem.Subscription.GetName())
-
-			return
-		}
-
-		hrsi.doSubscriptionWithRetries(retryInterval, retries)
-	}, loopPeriod, hrsi.stopch)
+			hrsi.doSubscriptionWithRetries(retryInterval, retries)
+		}, loopPeriod, hrsi.stopch)
+	}()
 }
 
+// Stop unsubscribes a subscriber item and waits for the current
+// doSubscription goroutine to finish before returning. This prevents a
+// concurrent new goroutine (started by the next Start call) from racing on
+// shared SubscriberItem fields such as hrsi.success.
 func (hrsi *SubscriberItem) Stop() {
 	if hrsi.stopch != nil {
 		close(hrsi.stopch)
 		hrsi.stopch = nil
 	}
+
+	hrsi.wg.Wait()
 }
 
 func (hrsi *SubscriberItem) doSubscriptionWithRetries(retryInterval time.Duration, retries int) {
@@ -174,6 +188,10 @@ func (hrsi *SubscriberItem) getRepoInfo(usePrimary bool) (*repo.IndexFile, strin
 }
 
 func (hrsi *SubscriberItem) doSubscription() {
+	// Reset success so that a stale true from a previous run cannot cause the
+	// retry loop in doSubscriptionWithRetries to exit early on the next failure.
+	hrsi.success = false
+
 	var indexFile *repo.IndexFile
 
 	var hash string

--- a/pkg/subscriber/helmrepo/helm_subscriber_item_lifecycle_test.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item_lifecycle_test.go
@@ -1,0 +1,187 @@
+// Copyright 2024 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helmrepo
+
+// Lifecycle tests for the goroutine serialization fix in helm_subscriber_item.go.
+//
+// The fix adds a sync.WaitGroup to SubscriberItem so that Stop() blocks until
+// the running doSubscription goroutine exits before a new one is started by
+// Start(restart=true). This eliminates the race condition where two concurrent
+// goroutines write to shared fields such as hrsi.success.
+//
+// These tests do not require a Kubernetes API server or a real Helm repository;
+// they exercise the synchronization primitives directly by manipulating the
+// unexported wg and stopch fields.
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+)
+
+// newHelmItem returns a minimal SubscriberItem with just enough state to
+// exercise the Start/Stop lifecycle without panicking.
+func newHelmItem() *SubscriberItem {
+	return &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "helm-lifecycle-test"},
+			},
+		},
+	}
+}
+
+// ─── Stop() nil-safety ────────────────────────────────────────────────────────
+
+// TestHelmStop_NilStopch verifies that Stop() on a zero-value SubscriberItem
+// (where stopch is nil and no goroutine has been started) does not panic.
+func TestHelmStop_NilStopch(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop() panicked on nil stopch: %v", r)
+		}
+	}()
+
+	newHelmItem().Stop()
+}
+
+// TestHelmStop_Idempotent verifies that calling Stop() twice does not cause a
+// double-close panic. The nil-guard on stopch must make the second call a no-op.
+func TestHelmStop_Idempotent(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Stop() panicked: %v", r)
+		}
+	}()
+
+	item := newHelmItem()
+	item.stopch = make(chan struct{})
+
+	item.Stop()
+	item.Stop()
+}
+
+// TestHelmStop_NilsStopchAfterReturn verifies that stopch is nil after Stop()
+// returns, ensuring a subsequent Start() can create a fresh channel safely.
+func TestHelmStop_NilsStopchAfterReturn(t *testing.T) {
+	item := newHelmItem()
+	item.stopch = make(chan struct{})
+	item.Stop()
+
+	if item.stopch != nil {
+		t.Fatal("expected stopch to be nil after Stop()")
+	}
+}
+
+// ─── WaitGroup semantics ──────────────────────────────────────────────────────
+
+// TestHelmStop_WaitsForRunningGoroutine verifies that Stop() blocks until the
+// WaitGroup drains — i.e. until the goroutine started by Start() has exited.
+//
+// The test registers a goroutine under the SubscriberItem's WaitGroup exactly
+// as Start() does, then asserts that Stop() does not return until the goroutine
+// is released.
+func TestHelmStop_WaitsForRunningGoroutine(t *testing.T) {
+	item := newHelmItem()
+	item.stopch = make(chan struct{})
+
+	goroutineStarted := make(chan struct{})
+	goroutineCanExit := make(chan struct{})
+
+	item.wg.Add(1)
+
+	go func() {
+		defer item.wg.Done()
+
+		close(goroutineStarted)
+		<-goroutineCanExit
+	}()
+
+	<-goroutineStarted
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		item.Stop()
+		close(stopReturned)
+	}()
+
+	// Stop() should be blocked while the goroutine is still running.
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before the goroutine exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(goroutineCanExit)
+
+	select {
+	case <-stopReturned:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after the goroutine exited")
+	}
+}
+
+// TestHelmStart_RestartSerializesGoroutines verifies that the Stop() call
+// inside Start(restart=true) blocks until the previous goroutine exits,
+// preventing two goroutines from concurrently accessing shared SubscriberItem
+// fields such as hrsi.success.
+func TestHelmStart_RestartSerializesGoroutines(t *testing.T) {
+	item := newHelmItem()
+	item.stopch = make(chan struct{})
+
+	firstGoroutineStarted := make(chan struct{})
+	firstGoroutineCanExit := make(chan struct{})
+	firstGoroutineExited := make(chan struct{})
+
+	item.wg.Add(1)
+
+	go func() {
+		defer item.wg.Done()
+		defer close(firstGoroutineExited)
+
+		close(firstGoroutineStarted)
+		<-firstGoroutineCanExit
+	}()
+
+	<-firstGoroutineStarted
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		item.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before the first goroutine exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(firstGoroutineCanExit)
+	<-firstGoroutineExited
+
+	select {
+	case <-stopReturned:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after the first goroutine exited")
+	}
+}

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
@@ -17,6 +17,7 @@ package objectbucket
 import (
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -45,6 +46,7 @@ type SubscriberItem struct {
 	bucket        string
 	objectStore   awsutils.ObjectStore
 	stopch        chan struct{}
+	wg            sync.WaitGroup
 	successful    bool
 	clusterAdmin  bool
 	syncinterval  int
@@ -79,36 +81,47 @@ func (obsi *SubscriberItem) Start(restart bool) {
 		return
 	}
 
-	go wait.Until(func() {
-		tw := obsi.SubscriberItem.Subscription.Spec.TimeWindow
-		if tw != nil {
-			nextRun := utils.NextStartPoint(tw, time.Now())
-			if nextRun > time.Duration(0) {
-				klog.Infof("Subscription is currently blocked by the time window. It %v/%v will be deployed after %v",
-					obsi.SubscriberItem.Subscription.GetNamespace(),
-					obsi.SubscriberItem.Subscription.GetName(), nextRun)
+	obsi.wg.Add(1)
+
+	go func() {
+		defer obsi.wg.Done()
+
+		wait.Until(func() {
+			tw := obsi.SubscriberItem.Subscription.Spec.TimeWindow
+			if tw != nil {
+				nextRun := utils.NextStartPoint(tw, time.Now())
+				if nextRun > time.Duration(0) {
+					klog.Infof("Subscription is currently blocked by the time window. It %v/%v will be deployed after %v",
+						obsi.SubscriberItem.Subscription.GetNamespace(),
+						obsi.SubscriberItem.Subscription.GetName(), nextRun)
+
+					return
+				}
+			}
+
+			// if the subscription pause lable is true, stop subscription here.
+			if utils.GetPauseLabel(obsi.SubscriberItem.Subscription) {
+				klog.Infof("Object bucket Subscription %v/%v is paused.", obsi.SubscriberItem.Subscription.GetNamespace(), obsi.SubscriberItem.Subscription.GetName())
 
 				return
 			}
-		}
 
-		// if the subscription pause lable is true, stop subscription here.
-		if utils.GetPauseLabel(obsi.SubscriberItem.Subscription) {
-			klog.Infof("Object bucket Subscription %v/%v is paused.", obsi.SubscriberItem.Subscription.GetNamespace(), obsi.SubscriberItem.Subscription.GetName())
-
-			return
-		}
-
-		obsi.doSubscriptionWithRetries(retryInterval, retries)
-	}, loopPeriod, obsi.stopch)
+			obsi.doSubscriptionWithRetries(retryInterval, retries)
+		}, loopPeriod, obsi.stopch)
+	}()
 }
 
-// Stop the subscriber.
+// Stop unsubscribes a subscriber item and waits for the current
+// doSubscription goroutine to finish before returning. This prevents a
+// concurrent new goroutine (started by the next Start call) from racing on
+// shared SubscriberItem fields such as obsi.successful and obsi.objectStore.
 func (obsi *SubscriberItem) Stop() {
 	if obsi.stopch != nil {
 		close(obsi.stopch)
 		obsi.stopch = nil
 	}
+
+	obsi.wg.Wait()
 }
 
 func (obsi *SubscriberItem) getChannelConfig(primary bool) (
@@ -256,6 +269,10 @@ func (obsi *SubscriberItem) doSubscriptionWithRetries(retryInterval time.Duratio
 }
 
 func (obsi *SubscriberItem) doSubscription() {
+	// Reset successful so that a stale true from a previous run cannot cause the
+	// retry loop in doSubscriptionWithRetries to exit early on the next failure.
+	obsi.successful = false
+
 	var folderName *string
 
 	//Update the secret and config map

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item_lifecycle_test.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item_lifecycle_test.go
@@ -1,0 +1,189 @@
+// Copyright 2024 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectbucket
+
+// Lifecycle tests for the goroutine serialization fix in
+// objectbucket_subscriber_item.go.
+//
+// The fix adds a sync.WaitGroup to SubscriberItem so that Stop() blocks until
+// the running doSubscription goroutine exits before a new one is started by
+// Start(restart=true). This eliminates the race condition where two concurrent
+// goroutines write to shared fields such as obsi.successful and
+// obsi.objectStore.
+//
+// These tests do not require a Kubernetes API server or a real object-store
+// endpoint; they exercise the synchronization primitives directly by
+// manipulating the unexported wg and stopch fields.
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+)
+
+// newObjItem returns a minimal SubscriberItem with just enough state to
+// exercise the Start/Stop lifecycle without panicking.
+func newObjItem() *SubscriberItem {
+	return &SubscriberItem{
+		SubscriberItem: appv1.SubscriberItem{
+			Subscription: &appv1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "obj-lifecycle-test"},
+			},
+		},
+	}
+}
+
+// ─── Stop() nil-safety ────────────────────────────────────────────────────────
+
+// TestObjStop_NilStopch verifies that Stop() on a zero-value SubscriberItem
+// (where stopch is nil and no goroutine has been started) does not panic.
+func TestObjStop_NilStopch(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop() panicked on nil stopch: %v", r)
+		}
+	}()
+
+	newObjItem().Stop()
+}
+
+// TestObjStop_Idempotent verifies that calling Stop() twice does not cause a
+// double-close panic. The nil-guard on stopch must make the second call a no-op.
+func TestObjStop_Idempotent(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Stop() panicked: %v", r)
+		}
+	}()
+
+	item := newObjItem()
+	item.stopch = make(chan struct{})
+
+	item.Stop()
+	item.Stop()
+}
+
+// TestObjStop_NilsStopchAfterReturn verifies that stopch is nil after Stop()
+// returns, ensuring a subsequent Start() can create a fresh channel safely.
+func TestObjStop_NilsStopchAfterReturn(t *testing.T) {
+	item := newObjItem()
+	item.stopch = make(chan struct{})
+	item.Stop()
+
+	if item.stopch != nil {
+		t.Fatal("expected stopch to be nil after Stop()")
+	}
+}
+
+// ─── WaitGroup semantics ──────────────────────────────────────────────────────
+
+// TestObjStop_WaitsForRunningGoroutine verifies that Stop() blocks until the
+// WaitGroup drains — i.e. until the goroutine started by Start() has exited.
+//
+// The test registers a goroutine under the SubscriberItem's WaitGroup exactly
+// as Start() does, then asserts that Stop() does not return until the goroutine
+// is released.
+func TestObjStop_WaitsForRunningGoroutine(t *testing.T) {
+	item := newObjItem()
+	item.stopch = make(chan struct{})
+
+	goroutineStarted := make(chan struct{})
+	goroutineCanExit := make(chan struct{})
+
+	item.wg.Add(1)
+
+	go func() {
+		defer item.wg.Done()
+
+		close(goroutineStarted)
+		<-goroutineCanExit
+	}()
+
+	<-goroutineStarted
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		item.Stop()
+		close(stopReturned)
+	}()
+
+	// Stop() should be blocked while the goroutine is still running.
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before the goroutine exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(goroutineCanExit)
+
+	select {
+	case <-stopReturned:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after the goroutine exited")
+	}
+}
+
+// TestObjStart_RestartSerializesGoroutines verifies that the Stop() call
+// inside Start(restart=true) blocks until the previous goroutine exits,
+// preventing two goroutines from concurrently accessing shared SubscriberItem
+// fields such as obsi.successful and obsi.objectStore.
+func TestObjStart_RestartSerializesGoroutines(t *testing.T) {
+	item := newObjItem()
+	item.stopch = make(chan struct{})
+
+	firstGoroutineStarted := make(chan struct{})
+	firstGoroutineCanExit := make(chan struct{})
+	firstGoroutineExited := make(chan struct{})
+
+	item.wg.Add(1)
+
+	go func() {
+		defer item.wg.Done()
+		defer close(firstGoroutineExited)
+
+		close(firstGoroutineStarted)
+		<-firstGoroutineCanExit
+	}()
+
+	<-firstGoroutineStarted
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		item.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop() returned before the first goroutine exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(firstGoroutineCanExit)
+	<-firstGoroutineExited
+
+	select {
+	case <-stopReturned:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after the first goroutine exited")
+	}
+}


### PR DESCRIPTION
… the manual refresh

* [X] I have taken backward compatibility into consideration.

https://redhat.atlassian.net/browse/ACM-33025

# Fix summary 
The PR addresses a race condition in all three subscriber types (git, helmrepo, objectbucket) where rapid manual-refresh-time annotation updates could cause deployed resources to be unexpectedly deleted and recreated. 

## Root cause
When the appsub `manual-refresh-time` annotation` is updated,   restart(restart=true) is called, the old code would close stopch (signalling the goroutine to stop) and immediately create a new goroutine. Because wait.Until only checks stopch between loop iterations — not during one — the old goroutine could still be mid-execution of doSubscription while the new goroutine started. Both goroutines would then concurrently read and write shared SubscriberItem fields like ghsi.resources, leading to a partial resource list being passed to ProcessSubResources. When ProcessSubResources received an incomplete list, it treated any missing resources as orphans and deleted them.

## What the commit changes

- Adds sync.WaitGroup wg to each SubscriberItem struct — tracks whether the background goroutine is running.

- Wraps the wait.Until goroutine with wg.Add(1) / defer wg.Done() — so the WaitGroup counter is non-zero for as long as the goroutine's body is executing.

- Makes Stop() block via wg.Wait() — instead of just closing stopch and returning immediately, Stop() now waits until the goroutine fully exits. This means the next Start(restart=true) call cannot proceed until the previous doSubscription run has completed and all shared fields (ghsi.resources, ghsi.successful, etc.) are in a stable state.

- Resets ghsi.successful = false at the start of doSubscription() — prevents a stale successful=true from a previous run from short-circuiting the commit-ID check and skipping a needed reconcile immediately after a restart.

- Adds lifecycle unit tests for all three subscriber types (git, helmrepo, objectbucket), covering nil-safety of Stop(), idempotency, channel cleanup, and the core WaitGroup serialization guarantee (i.e. a second goroutine cannot start until the first has fully exited).

## New data flow with the fix

- doSubscription in a go routine is called every loop period (default value is 3 min) for syncing app resources from git repo to the current cluster.  the stop channel of the got routine is initialized. the wait group task counter is incremented by 1.
-  user to update `apps.open-cluster-management.io/manual-refresh-time` annotation in the appsub to trigger a manual sync. 
-  the subscription controller is triggered to restart a new doSubscription go routine by calling `Start(restart=true)`
-  the subscription controller stops the current go routine by calling `ghsi.Stop()`, where  
    1. The stop channel `ghsi.stopch` is closed.  It informs the the current doSubscription go routine to exit
    2.  wait for the wait group task count to be zero `ghsi.wg.Wait()`
-  then  the current doSubscription go routine is done as the `ghsi.stopch` channel is closed. the wait group task counter is decremented by 1. 
- once the wait group task counter is zero, the `ghsi.Stop()` is unblocked, then a new go routine will be started for another sync-up