### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/build/Dockerfile.art
+++ b/build/Dockerfile.art
@@ -1,0 +1,79 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+
+WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
+COPY . .
+
+RUN rm -fr vendor && \
+        go mod vendor && \
+        CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
+
+# Update git submodules
+RUN git submodule update --init
+
+# Build the helm binary
+# VERSION is specified here because the builder sets it, but Helm also relies on it for versioning
+RUN GOEXPERIMENT=strictfipsruntime VERSION="" ./build/build-binary.sh "external/helm" "CGO_ENABLED=1 make build"
+
+# Build the policy generator plugin binary
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime ./build/build-binary.sh "/external/policy-generator-plugin" "make build-binary"
+
+# Build a policy generator plugin RHEL8 binary that can be mounted to other containers
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_1.25 AS plugin-builder-rhel8
+
+WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
+COPY . .
+
+RUN git submodule update --init
+
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime ./build/build-binary.sh "/external/policy-generator-plugin" "make build-binary"
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+RUN  microdnf update -y \
+        && microdnf install -y git-core openssh-clients tzdata \
+        && microdnf clean all
+
+ENV OPERATOR=/usr/local/bin/multicluster-operators-subscription \
+        USER_UID=1001 \
+        USER_NAME=multicluster-operators-subscription \
+        ZONEINFO=/usr/share/timezone \
+        KUSTOMIZE_PLUGIN_HOME=/etc/kustomize/plugin \
+        POLICY_GEN_ENABLE_HELM=true \
+        APPSUB_BUILD_DIR=/go/src/github.com/stolostron/multicluster-operators-subscription
+
+LABEL \
+    name="rhacm2/multicluster-operators-subscription-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    com.redhat.component="multicloud-operators-subscription" \
+    description="multicluster subscription controller" \
+    maintainer="acm-contact@redhat.com" \
+    io.k8s.description="multicluster subscription controller" \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    summary="multicluster subscription controller" \
+    io.k8s.display-name="multicluster subscription" \
+    io.openshift.tags="mce acm multicloud-operators-subscription"
+
+# install operator binary
+COPY --from=plugin-builder ${APPSUB_BUILD_DIR}/build/_output/bin/multicluster-operators-subscription ${OPERATOR}
+COPY --from=plugin-builder ${APPSUB_BUILD_DIR}/build/_output/bin/multicluster-operators-placementrule /usr/local/bin/
+COPY --from=plugin-builder ${APPSUB_BUILD_DIR}/build/_output/bin/uninstall-crd /usr/local/bin/
+COPY --from=plugin-builder ${APPSUB_BUILD_DIR}/build/_output/bin/appsubsummary /usr/local/bin/
+
+# install the policy generator Kustomize plugin
+RUN mkdir -p $KUSTOMIZE_PLUGIN_HOME/policy.open-cluster-management.io/v1/policygenerator
+COPY --from=plugin-builder ${APPSUB_BUILD_DIR}/external/policy-generator-plugin/PolicyGenerator $KUSTOMIZE_PLUGIN_HOME/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
+COPY --from=plugin-builder ${APPSUB_BUILD_DIR}/external/helm/bin/helm /usr/local/bin/
+
+# make available a RHEL8 policy generator binary for mounting in other containers
+RUN mkdir /policy-generator
+COPY --from=plugin-builder-rhel8 ${APPSUB_BUILD_DIR}/external/policy-generator-plugin/PolicyGenerator /policy-generator/PolicyGenerator-rhel8
+# Symlink to the old binary name for compatibility
+RUN ln -s /policy-generator/PolicyGenerator-rhel8 /policy-generator/PolicyGenerator-not-fips-compliant
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)