### PR TITLE
Fix go.sum missing entry for moby/spdystream when building helm binary

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/pkg/mod/helm.sh/helm/v3@v3.20.2
 # Fix CVE in github.com/moby/spdystream before building the helm binary
 RUN chmod -R u+w . && \
         go mod edit -replace github.com/moby/spdystream=github.com/moby/spdystream@v0.5.1 && \
+        GONOSUMDB=* go mod download github.com/moby/spdystream@v0.5.1 && \
         CGO_ENABLED=1 make build
 
 WORKDIR /policy-generator

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -9,6 +9,7 @@ WORKDIR /go/pkg/mod/helm.sh/helm/v3@v3.20.2
 # Fix CVE in github.com/moby/spdystream before building the helm binary
 RUN chmod -R u+w . && \
         go mod edit -replace github.com/moby/spdystream=github.com/moby/spdystream@v0.5.1 && \
+        GONOSUMDB=* go mod download github.com/moby/spdystream@v0.5.1 && \
         CGO_ENABLED=1 make build
 
 WORKDIR /policy-generator

--- a/build/build-binary.sh
+++ b/build/build-binary.sh
@@ -78,6 +78,14 @@ fi
 for _r in "${go_replace_directives[@]}"; do
   echo "* Applying go mod replace: ${_r}"
   go mod edit -replace "${_r}"
+  # Populate go.sum from the module cache without consulting the sum database,
+  # so that go mod vendor succeeds in hermetic (network-isolated) builds.
+  # Use || true because the module may already be present in go.sum (e.g. newer
+  # helm versions that already pin this version natively), in which case the
+  # download is not needed and may not be available in the prefetch cache.
+  _new_module="${_r#*=}"
+  echo "* Downloading replacement to populate go.sum: ${_new_module}"
+  GONOSUMDB=* go mod download "${_new_module}" || true
 done
 
 rm -rf vendor


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.
