### PR TITLE
ACM-38063: Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/multicloud-operators-subscription/multicloud-operators-subscription/go'
 defaults:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -25,7 +25,7 @@ jobs:
       RUN_ON: github
     strategy:
       matrix:
-        go: [ '1.25' ]
+        go: [ '1.26' ]
     name: KinD tests
     steps:
     # Checks out a copy of your repository on the ubuntu-latest machine
@@ -34,7 +34,7 @@ jobs:
     - name: Set up go version
       uses: actions/setup-go@v3
       with:
-        go-version: '~1.25' # The Go version to download (if necessary) and use.
+        go-version: '~1.26' # The Go version to download (if necessary) and use.
     - run: go version
     
     - name: Run e2e test on KinD cluster

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS plugin-builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS plugin-builder
 ENV POLICY_GENERATOR_TAG=release-2.15
 
 WORKDIR /go/src/github.com/open-cluster-management/multicloud-operators-subscription

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 ENV POLICY_GENERATOR_TAG=release-2.15
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .
@@ -20,7 +20,7 @@ RUN VERSION="" ./build/build-binary.sh "external/helm" "CGO_ENABLED=1 make build
 RUN ./build/build-binary.sh "/external/policy-generator-plugin" "make build-binary"
 
 # Build a policy generator plugin RHEL8 binary that can be mounted to other containers
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.25 AS plugin-builder-rhel8
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.26 AS plugin-builder-rhel8
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/multicloud-operators-subscription
 
-go 1.25.8
+go 1.26
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/pkg/placementrule/controller/placementrule/placementdecision.go
+++ b/pkg/placementrule/controller/placementrule/placementdecision.go
@@ -146,7 +146,7 @@ func (r *ReconcilePlacementRuleStatus) createOrUpdatePlacementDecision(
 	clusterDecisions []clusterapi.ClusterDecision,
 ) error {
 	if len(clusterDecisions) > maxNumOfClusterDecisions {
-		return fmt.Errorf("the number of clusterdecisions %q exceeds the max limitation %q", len(clusterDecisions), maxNumOfClusterDecisions)
+		return fmt.Errorf("the number of clusterdecisions %d exceeds the max limitation %d", len(clusterDecisions), maxNumOfClusterDecisions)
 	}
 
 	pdNsn := types.NamespacedName{Namespace: placementRule.Namespace, Name: placementDecisionName}


### PR DESCRIPTION
## Summary

Bump Go builder images from 1.25 to 1.26 to address CVE-2026-27145 (crypto/x509 DoS).

## Changes

- `go.mod`: `go 1.25` → `go 1.26`
- `build/Dockerfile`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.prow`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.rhtap`: brew builder `rhel_9_1.25` → `rhel_9_1.26` AND `rhel_8_1.25` → `rhel_8_1.26`
- `.github/workflows/kind.yml`: Go version `1.25` → `1.26`
- `.github/workflows/e2e.yml`: Go version `1.25` → `1.26`