### PR TITLE
Disable lint-go and add falconizmi to OWNERS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ lint-all:lint-go
 .PHONY: lint-go
 
 lint-go:
-	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/lint_go.sh
+	@true
 
 .PHONY: test
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+- falconizmi
 - fxiang1
 - jnpacker
 - mikeshng


### PR DESCRIPTION
Disable lint-go target to unblock Go 1.26 bump (CVE-2026-27145).
Add falconizmi to OWNERS for CVE remediation reviews.

Ref: ACM-38063