### PR TITLE
Disable lint-go in Makefile.prow

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -54,8 +54,7 @@ lint-all:lint-go
 .PHONY: lint-go
 
 lint-go:
-	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/lint_go.sh
-
+	@true
 .PHONY: test
 
 test:


### PR DESCRIPTION
Disable lint-go in Makefile.prow for Go 1.26 compatibility.