### PR TITLE
Remove redundant Helm templating from networkpolicy.yaml bundle manifest

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/networkpolicy.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/networkpolicy.yaml
@@ -47,7 +47,6 @@
 # true). Note that once this action is present, this file must be rendered through the Helm
 # template engine (e.g. `helm template`) rather than applied directly as plain YAML, since Go's
 # text/template scans the whole file - including comments - for its delimiters.
-{{- if .Values.global.networkPolicies.enabled }}
 ---
 # multicluster-operators-hub-subscription
 apiVersion: networking.k8s.io/v1
@@ -293,4 +292,3 @@ spec:
       port: 443
     - protocol: TCP
       port: 6443
-{{- end }}


### PR DESCRIPTION
## Description

`deploy/olm-catalog/multicluster-operators-subscription/manifests/networkpolicy.yaml` (added in #1702) wraps its resources in `{{- if .Values.global.networkPolicies.enabled }}` / `{{- end }}`. Since this file lives in the OLM bundle's `manifests/` directory — which is meant to contain plain, valid Kubernetes YAML that OLM applies directly via the CSV install path — the embedded Go/Helm template syntax breaks any tool that parses it as plain YAML.

This surfaced as a scheduled CI failure in `stolostron/multiclusterhub-operator`'s bundle-regeneration automation: `bundles-to-charts.py`'s `addCRDs()` crashed with `yaml.parser.ParserError` on this file (`{{-` isn't valid inside a YAML flow node), which took down chart regeneration for every other component processed in the same run, not just this one.

## Why removing it is correct, not just a workaround

The wrapping is also redundant. `multiclusterhub-operator`'s chart-generation tooling (`installer-dev-tools`'s `bundles-to-charts.py`) already automatically wraps **every** `NetworkPolicy` resource it extracts from a bundle with the exact same `{{- if .Values.global.networkPolicies.enabled }}` condition when building the toggle Helm chart — confirmed by re-running the actual chart generation against this file with the wrapping removed:

```
INFO Found 6 NetworkPolicy templates
INFO Wrapped NetworkPolicy template with networkPolicies.enabled condition: .../multicluster-operators-hub-subscription-policy-networkpolicy.yaml
... (all 6 policies)
```

The generated chart output confirms the `networkPolicies.enabled` gate is present either way — this file doesn't need to add it manually, and the manual copy was the one causing the parse failure.

## Why this targets `main`

`release-5.0` and `release-5.1` are kept in sync with `main` via a fast-forward cronjob, so fixing `main` is sufficient — merging directly into `release-5.0` would have broken that fast-forward relationship (main would no longer be a strict descendant of release-5.0).

## Changes Made

Removed the two `{{- if }}` / `{{- end }}` lines. Everything else in the file is unchanged — it's still exactly the same 6 `NetworkPolicy` resources.

## Testing

- `yaml.safe_load_all()` on the file now succeeds, parsing all 6 `NetworkPolicy` documents correctly (previously raised `ParserError`).
- Ran the real `multiclusterhub-operator` chart-regeneration pipeline (`generate-shell.py --update-charts-from-bundles`) against this branch end-to-end: completes successfully, and the resulting toggle chart's `NetworkPolicy` templates are still correctly gated behind `global.networkPolicies.enabled` (see log excerpt above).
- [ ] I have taken backward compatibility into consideration. — no behavior change for consumers of the generated Helm chart; this only affects the raw OLM bundle manifest, which OLM would otherwise choke on if it ever tried to render this file's Go template syntax outside of `helm template`.

## Related

- Companion resilience fix so a single unparseable manifest can't crash the whole automation run for every other component in the future: stolostron/installer-dev-tools#169

/cc @falconizmi @fxiang1 @jnpacker @mikeshng @rokej @philipwu08 @xiangjingli
