### PR TITLE
a non subscription-admin should not deploy cluster-scoped resources b…

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -483,7 +483,7 @@ func (r *ReconcileSubscription) doReconcile(instance *appv1.Subscription) error 
 	subtype := strings.ToLower(string(subitem.Channel.Spec.Type))
 
 	if strings.EqualFold(subtype, chnv1.ChannelTypeGit) || strings.EqualFold(subtype, chnv1.ChannelTypeGitHub) ||
-		strings.EqualFold(subtype, chnv1.ChannelTypeObjectBucket) {
+		strings.EqualFold(subtype, chnv1.ChannelTypeObjectBucket) || strings.EqualFold(subtype, chnv1.ChannelTypeHelmRepo) {
 		annotations := instance.GetAnnotations()
 
 		if utils.IsClusterAdmin(r.hubclient, instance, r.eventRecorder) {

--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -231,6 +231,86 @@ func TestDoReconcileIncludingErrorPaths(t *testing.T) {
 	g.Expect(rec.doReconcile(instance)).NotTo(gomega.HaveOccurred())
 }
 
+// TestDoReconcileHelmRepoRechecksClusterAdmin covers the fix that added
+// chnv1.ChannelTypeHelmRepo to the set of channel types whose cluster-admin
+// annotation is re-verified via utils.IsClusterAdmin on every reconcile.
+// Before the fix, Helm-repo subscriptions were excluded from this recheck, so
+// a stale "cluster-admin: true" annotation (e.g. left over after the
+// subscription is no longer considered hub-propagated) would never be
+// de-escalated.
+func TestDoReconcileHelmRepoRechecksClusterAdmin(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c = mgr.GetClient()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	rec := newReconciler(mgr, mgr.GetClient(), nil, false).(*ReconcileSubscription)
+
+	helmChnKey := types.NamespacedName{Name: "test-helmrepo-chn", Namespace: chnkey.Namespace}
+	helmChn := &chnv1alpha1.Channel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmChnKey.Name,
+			Namespace: helmChnKey.Namespace,
+		},
+		Spec: chnv1alpha1.ChannelSpec{
+			Type:     chnv1alpha1.ChannelTypeHelmRepo,
+			Pathname: "https://charts.example.com/",
+		},
+	}
+	g.Expect(c.Create(context.TODO(), helmChn)).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), helmChn)
+
+	instance := &appv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-helmrepo-clusteradmin-recheck",
+			Namespace: subkey.Namespace,
+			Annotations: map[string]string{
+				appv1alpha1.AnnotationHosting:      "hub-namespace/hub-sub",
+				appv1alpha1.AnnotationClusterAdmin: "true",
+			},
+		},
+		Spec: appv1alpha1.SubscriptionSpec{
+			Channel: helmChnKey.String(),
+		},
+	}
+	g.Expect(c.Create(context.TODO(), instance)).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), instance)
+
+	// The subscription is (simulated as) propagated from the hub and there is
+	// no ACM mutating webhook in this test environment, so IsClusterAdmin
+	// respects the existing cluster-admin annotation and keeps it set.
+	g.Expect(rec.doReconcile(instance)).NotTo(gomega.HaveOccurred())
+	g.Expect(instance.GetAnnotations()[appv1alpha1.AnnotationClusterAdmin]).To(gomega.Equal("true"))
+
+	// Simulate the subscription no longer being considered hub-propagated
+	// (e.g. the hosting-subscription annotation is gone) while the
+	// cluster-admin annotation is still stale/true from before. If Helm-repo
+	// subscriptions are correctly rechecked on every reconcile, the stale
+	// annotation must be removed.
+	annotations := instance.GetAnnotations()
+	delete(annotations, appv1alpha1.AnnotationHosting)
+	instance.SetAnnotations(annotations)
+
+	g.Expect(rec.doReconcile(instance)).NotTo(gomega.HaveOccurred())
+	g.Expect(instance.GetAnnotations()[appv1alpha1.AnnotationClusterAdmin]).NotTo(gomega.Equal("true"))
+}
+
 type testClock struct {
 	timestamp string
 }

--- a/pkg/helmrelease/release/clusterscope.go
+++ b/pkg/helmrelease/release/clusterscope.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"helm.sh/helm/v3/pkg/postrender"
+	"helm.sh/helm/v3/pkg/releaseutil"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog"
+)
+
+// clusterScopeGate is a Helm PostRenderer that blocks a chart's rendered
+// manifest from being applied if it contains cluster-scoped resources
+// (e.g. ClusterRole, ClusterRoleBinding, Namespace, CustomResourceDefinition)
+// and the owning Subscription was not created/updated by a subscription admin.
+//
+// Without this gate, a non-admin user could smuggle a cluster-scoped resource
+// (such as a ClusterRoleBinding granting cluster-admin) inside a Helm chart
+// and have the operator, which applies charts with elevated credentials,
+// deploy it on their behalf.
+type clusterScopeGate struct {
+	restMapper meta.RESTMapper
+	isAdmin    bool
+}
+
+// newClusterScopeGate returns a PostRenderer enforcing the cluster-scoped
+// resource restriction described above. When isAdmin is true, it is a no-op.
+func newClusterScopeGate(restMapper meta.RESTMapper, isAdmin bool) postrender.PostRenderer {
+	return &clusterScopeGate{restMapper: restMapper, isAdmin: isAdmin}
+}
+
+func (g *clusterScopeGate) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	if g.isAdmin || renderedManifests == nil {
+		return renderedManifests, nil
+	}
+
+	blocked, err := g.findClusterScopedResources(renderedManifests.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(blocked) > 0 {
+		return nil, fmt.Errorf("not deployed by a subscription admin. cluster-scoped resource(s) %s are not deployed",
+			strings.Join(blocked, ", "))
+	}
+
+	return renderedManifests, nil
+}
+
+// findClusterScopedResources returns a human readable identifier for every
+// cluster-scoped resource found in the manifest. If the scope of a resource
+// kind cannot be determined (e.g. its CRD isn't registered with the API
+// server yet), it is treated the same as an unresolvable GVK elsewhere in
+// this codebase and reported as blocked, erring on the side of caution.
+func (g *clusterScopeGate) findClusterScopedResources(manifest string) ([]string, error) {
+	var blocked []string
+
+	for _, doc := range releaseutil.SplitManifests(manifest) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal([]byte(doc), obj); err != nil {
+			// Not a valid k8s object (e.g. a NOTES.txt fragment); let Helm's
+			// own manifest handling surface any real errors downstream.
+			continue
+		}
+
+		gvk := obj.GroupVersionKind()
+		if gvk.Kind == "" {
+			continue
+		}
+
+		mapping, err := g.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			klog.Warningf("cluster-scope gate: unable to determine scope of %s, blocking as a precaution: %v",
+				gvk.String(), err)
+
+			blocked = append(blocked, fmt.Sprintf("%s kind: %s name: %s (unknown scope)",
+				obj.GetAPIVersion(), obj.GetKind(), obj.GetName()))
+
+			continue
+		}
+
+		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+			blocked = append(blocked, fmt.Sprintf("%s kind: %s name: %s",
+				obj.GetAPIVersion(), obj.GetKind(), obj.GetName()))
+		}
+	}
+
+	return blocked, nil
+}

--- a/pkg/helmrelease/release/clusterscope_test.go
+++ b/pkg/helmrelease/release/clusterscope_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func newTestRESTMapper() meta.RESTMapper {
+	var defaultVersion []schema.GroupVersion
+	restMapper := meta.NewDefaultRESTMapper(defaultVersion)
+
+	restMapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
+	restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
+	restMapper.Add(
+		schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
+		meta.RESTScopeRoot)
+	restMapper.Add(
+		schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+		meta.RESTScopeRoot)
+	restMapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, meta.RESTScopeRoot)
+
+	return restMapper
+}
+
+const namespacedManifest = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: ns1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy1
+  namespace: ns1
+`
+
+const clusterScopedManifest = namespacedManifest + `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: attacker-crb
+`
+
+func TestClusterScopeGate_AdminAllowsClusterScopedResources(t *testing.T) {
+	gate := newClusterScopeGate(newTestRESTMapper(), true)
+
+	out, err := gate.Run(bytes.NewBufferString(clusterScopedManifest))
+
+	assert.NoError(t, err)
+	assert.Equal(t, clusterScopedManifest, out.String())
+}
+
+func TestClusterScopeGate_NonAdminBlocksClusterScopedResource(t *testing.T) {
+	gate := newClusterScopeGate(newTestRESTMapper(), false)
+
+	out, err := gate.Run(bytes.NewBufferString(clusterScopedManifest))
+
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.Contains(t, err.Error(), "not deployed by a subscription admin")
+	assert.Contains(t, err.Error(), "ClusterRoleBinding")
+	assert.Contains(t, err.Error(), "attacker-crb")
+}
+
+func TestClusterScopeGate_NonAdminAllowsNamespacedOnlyManifest(t *testing.T) {
+	gate := newClusterScopeGate(newTestRESTMapper(), false)
+
+	out, err := gate.Run(bytes.NewBufferString(namespacedManifest))
+
+	assert.NoError(t, err)
+	assert.Equal(t, namespacedManifest, out.String())
+}
+
+func TestClusterScopeGate_NonAdminBlocksExplicitNamespaceResource(t *testing.T) {
+	manifest := `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: attacker-ns
+`
+	gate := newClusterScopeGate(newTestRESTMapper(), false)
+
+	out, err := gate.Run(bytes.NewBufferString(manifest))
+
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.True(t, strings.Contains(err.Error(), "Namespace"))
+}
+
+func TestClusterScopeGate_UnresolvableKindIsBlockedAsPrecaution(t *testing.T) {
+	manifest := `
+apiVersion: example.com/v1
+kind: SomeUnknownCRD
+metadata:
+  name: mystery
+`
+	gate := newClusterScopeGate(newTestRESTMapper(), false)
+
+	out, err := gate.Run(bytes.NewBufferString(manifest))
+
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.Contains(t, err.Error(), "unknown scope")
+}
+
+func TestClusterScopeGate_NilManifestIsNoop(t *testing.T) {
+	gate := newClusterScopeGate(newTestRESTMapper(), false)
+
+	out, err := gate.Run(nil)
+
+	assert.NoError(t, err)
+	assert.Nil(t, out)
+}

--- a/pkg/helmrelease/release/manager.go
+++ b/pkg/helmrelease/release/manager.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -65,12 +66,20 @@ type manager struct {
 	actionConfig   *action.Configuration
 	storageBackend *storage.Storage
 	kubeClient     kube.Interface
+	restMapper     meta.RESTMapper
 
 	releaseName string
 	namespace   string
 
 	values map[string]interface{}
 	status *appv1.HelmAppStatus
+
+	// isAdmin reflects whether the owning Subscription carries the
+	// cluster-admin annotation, i.e. was created/updated by a user bound to
+	// the open-cluster-management:subscription-admin ClusterRoleBinding.
+	// Only subscription admins may deploy charts containing cluster-scoped
+	// resources; see clusterscope.go.
+	isAdmin bool
 
 	isInstalled       bool
 	isUpgradeRequired bool
@@ -170,6 +179,7 @@ func (m manager) getCandidateRelease(namespace, name string, chart *cpb.Chart,
 	upgrade := action.NewUpgrade(m.actionConfig)
 	upgrade.Namespace = namespace
 	upgrade.DryRun = true
+	upgrade.PostRenderer = newClusterScopeGate(m.restMapper, m.isAdmin)
 
 	return upgrade.Run(name, chart, values)
 }
@@ -185,6 +195,10 @@ func (m manager) InstallRelease(ctx context.Context, opts ...InstallOption) (*rp
 			return nil, fmt.Errorf("failed to apply install option: %w", err)
 		}
 	}
+
+	// Enforce the cluster-scoped resource restriction last so no InstallOption
+	// can accidentally override it.
+	install.PostRenderer = newClusterScopeGate(m.restMapper, m.isAdmin)
 
 	return install.Run(m.chart, m.values)
 }
@@ -206,6 +220,10 @@ func (m manager) UpgradeRelease(ctx context.Context, opts ...UpgradeOption) (*rp
 			return nil, nil, fmt.Errorf("failed to apply upgrade option: %w", err)
 		}
 	}
+
+	// Enforce the cluster-scoped resource restriction last so no UpgradeOption
+	// can accidentally override it.
+	upgrade.PostRenderer = newClusterScopeGate(m.restMapper, m.isAdmin)
 
 	upgradedRelease, err := upgrade.Run(m.releaseName, m.chart, m.values)
 	if err != nil {

--- a/pkg/helmrelease/release/manager_factory.go
+++ b/pkg/helmrelease/release/manager_factory.go
@@ -18,6 +18,7 @@ package release
 
 import (
 	"fmt"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -32,6 +33,7 @@ import (
 	crmanager "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/helmrelease/v1"
+	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/helmrelease/client"
 )
 
@@ -51,6 +53,15 @@ type managerFactory struct {
 // NewManagerFactory returns a new Helm manager factory capable of installing and uninstalling releases.
 func NewManagerFactory(mgr crmanager.Manager, chartDir string) ManagerFactory {
 	return &managerFactory{mgr, chartDir}
+}
+
+// isClusterAdminCR reports whether the HelmRelease CR carries the
+// cluster-admin annotation, i.e. its owning Subscription was created/updated
+// by a user bound to the open-cluster-management:subscription-admin
+// ClusterRoleBinding. Only subscription admins are allowed to deploy charts
+// containing cluster-scoped resources; see clusterscope.go.
+func isClusterAdminCR(cr *unstructured.Unstructured) bool {
+	return strings.EqualFold(cr.GetAnnotations()[appsubv1.AnnotationClusterAdmin], "true")
 }
 
 func (f managerFactory) NewManager(cr *unstructured.Unstructured, overrideValues map[string]string) (Manager, error) {
@@ -112,17 +123,25 @@ func (f managerFactory) NewManager(cr *unstructured.Unstructured, overrideValues
 		Log:              func(_ string, _ ...interface{}) {},
 	}
 
+	// The cluster-admin annotation is copied onto the HelmRelease CR (see
+	// utils.CreateHelmCRManifest) whenever the owning Subscription was
+	// created/updated by a subscription admin. Only subscription admins are
+	// allowed to deploy charts containing cluster-scoped resources.
+	isAdmin := isClusterAdminCR(cr)
+
 	return &manager{
 		actionConfig:   actionConfig,
 		storageBackend: storageBackend,
 		kubeClient:     ownerRefClient,
+		restMapper:     restMapper,
 
 		releaseName: releaseName,
 		namespace:   cr.GetNamespace(),
 
-		chart:  crChart,
-		values: values,
-		status: appv1.StatusFor(cr),
+		chart:   crChart,
+		values:  values,
+		status:  appv1.StatusFor(cr),
+		isAdmin: isAdmin,
 	}, nil
 }
 

--- a/pkg/helmrelease/release/manager_factory_test.go
+++ b/pkg/helmrelease/release/manager_factory_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+)
+
+func newHelmReleaseCR(annotations map[string]string) *unstructured.Unstructured {
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "apps.open-cluster-management.io", Version: "v1", Kind: "HelmRelease",
+	})
+	cr.SetName("test-release")
+	cr.SetNamespace("test-ns")
+	cr.SetAnnotations(annotations)
+
+	return cr
+}
+
+// TestIsClusterAdminCR verifies that the manager factory correctly derives
+// isAdmin from the apps.open-cluster-management.io/cluster-admin annotation
+// copied onto the HelmRelease CR (see utils.CreateHelmCRManifest), which is
+// what NewManager passes to the clusterScopeGate PostRenderer.
+func TestIsClusterAdminCR(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "annotation true", annotations: map[string]string{appsubv1.AnnotationClusterAdmin: "true"}, want: true},
+		{name: "annotation True mixed case", annotations: map[string]string{appsubv1.AnnotationClusterAdmin: "True"}, want: true},
+		{name: "annotation TRUE upper case", annotations: map[string]string{appsubv1.AnnotationClusterAdmin: "TRUE"}, want: true},
+		{name: "annotation false", annotations: map[string]string{appsubv1.AnnotationClusterAdmin: "false"}, want: false},
+		{name: "annotation missing", annotations: map[string]string{"other": "value"}, want: false},
+		{name: "no annotations at all", annotations: nil, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := newHelmReleaseCR(tc.annotations)
+			assert.Equal(t, tc.want, isClusterAdminCR(cr))
+		})
+	}
+}

--- a/pkg/helmrelease/release/manager_test.go
+++ b/pkg/helmrelease/release/manager_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/action"
+	cpb "helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/registry"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+// testActionConfig returns a Helm action.Configuration backed entirely by
+// in-memory/no-op implementations (no real Kubernetes API server or network
+// access required), mirroring the fixture Helm itself uses in
+// pkg/action/action_test.go.
+func testActionConfig(t *testing.T) *action.Configuration {
+	t.Helper()
+
+	registryClient, err := registry.NewClient()
+	require.NoError(t, err)
+
+	return &action.Configuration{
+		Releases:       storage.Init(driver.NewMemory()),
+		KubeClient:     &kubefake.PrintingKubeClient{Out: io.Discard},
+		Capabilities:   chartutil.DefaultCapabilities,
+		RegistryClient: registryClient,
+		Log:            func(_ string, _ ...interface{}) {},
+	}
+}
+
+func namespacedOnlyChart(name string) *cpb.Chart {
+	return &cpb.Chart{
+		Metadata: &cpb.Metadata{APIVersion: "v2", Name: name, Version: "0.1.0"},
+		Templates: []*cpb.File{
+			{Name: "templates/configmap.yaml", Data: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+`)},
+		},
+	}
+}
+
+func clusterScopedChart(name string) *cpb.Chart {
+	return &cpb.Chart{
+		Metadata: &cpb.Metadata{APIVersion: "v2", Name: name, Version: "0.2.0"},
+		Templates: []*cpb.File{
+			{Name: "templates/configmap.yaml", Data: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+`)},
+			{Name: "templates/crb.yaml", Data: []byte(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: attacker-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: User
+  name: attacker
+`)},
+		},
+	}
+}
+
+// TestManagerInstallRelease_NonAdminBlocksClusterScopedResource proves that
+// manager.InstallRelease actually wires the clusterScopeGate PostRenderer in
+// (via m.restMapper/m.isAdmin), not just that the gate works in isolation.
+func TestManagerInstallRelease_NonAdminBlocksClusterScopedResource(t *testing.T) {
+	m := &manager{
+		actionConfig: testActionConfig(t),
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      false,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        clusterScopedChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+
+	_, err := m.InstallRelease(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not deployed by a subscription admin")
+	assert.Contains(t, err.Error(), "ClusterRoleBinding")
+}
+
+// TestManagerInstallRelease_AdminAllowsClusterScopedResource is the admin
+// counterpart: the same chart succeeds when isAdmin is true.
+func TestManagerInstallRelease_AdminAllowsClusterScopedResource(t *testing.T) {
+	m := &manager{
+		actionConfig: testActionConfig(t),
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      true,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        clusterScopedChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+
+	rel, err := m.InstallRelease(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, rel)
+	assert.Contains(t, rel.Manifest, "ClusterRoleBinding")
+}
+
+// TestManagerInstallRelease_NonAdminAllowsNamespacedOnlyChart verifies the
+// gate doesn't get in the way of ordinary charts that contain no
+// cluster-scoped resources at all.
+func TestManagerInstallRelease_NonAdminAllowsNamespacedOnlyChart(t *testing.T) {
+	m := &manager{
+		actionConfig: testActionConfig(t),
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      false,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        namespacedOnlyChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+
+	rel, err := m.InstallRelease(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, rel)
+	assert.Contains(t, rel.Manifest, "ConfigMap")
+}
+
+// TestManagerUpgradeRelease_NonAdminBlocksClusterScopedResource proves the
+// gate is also wired into UpgradeRelease: an existing release may not be
+// upgraded to a revision that introduces a cluster-scoped resource unless
+// isAdmin is true.
+func TestManagerUpgradeRelease_NonAdminBlocksClusterScopedResource(t *testing.T) {
+	cfg := testActionConfig(t)
+
+	installer := &manager{
+		actionConfig: cfg,
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      true,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        namespacedOnlyChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+	_, err := installer.InstallRelease(context.Background())
+	require.NoError(t, err)
+
+	upgrader := &manager{
+		actionConfig: cfg,
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      false,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        clusterScopedChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+
+	_, upgraded, err := upgrader.UpgradeRelease(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, upgraded)
+	assert.Contains(t, err.Error(), "not deployed by a subscription admin")
+}
+
+// TestManagerUpgradeRelease_AdminAllowsClusterScopedResource is the admin
+// counterpart of the upgrade test above.
+func TestManagerUpgradeRelease_AdminAllowsClusterScopedResource(t *testing.T) {
+	cfg := testActionConfig(t)
+
+	installer := &manager{
+		actionConfig: cfg,
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      true,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        namespacedOnlyChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+	_, err := installer.InstallRelease(context.Background())
+	require.NoError(t, err)
+
+	upgrader := &manager{
+		actionConfig: cfg,
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      true,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        clusterScopedChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+
+	_, upgraded, err := upgrader.UpgradeRelease(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, upgraded)
+	assert.Contains(t, upgraded.Manifest, "ClusterRoleBinding")
+}
+
+// TestManagerGetCandidateRelease_EnforcesClusterScopeGate proves the private
+// getCandidateRelease helper (used by Sync to compute isUpgradeRequired)
+// also enforces the gate during its dry-run upgrade.
+func TestManagerGetCandidateRelease_EnforcesClusterScopeGate(t *testing.T) {
+	cfg := testActionConfig(t)
+
+	installer := &manager{
+		actionConfig: cfg,
+		restMapper:   newTestRESTMapper(),
+		isAdmin:      true,
+		releaseName:  "test-release",
+		namespace:    "ns1",
+		chart:        namespacedOnlyChart("test-release"),
+		values:       map[string]interface{}{},
+	}
+	_, err := installer.InstallRelease(context.Background())
+	require.NoError(t, err)
+
+	nonAdmin := manager{actionConfig: cfg, restMapper: newTestRESTMapper(), isAdmin: false}
+	_, err = nonAdmin.getCandidateRelease("ns1", "test-release", clusterScopedChart("test-release"), map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not deployed by a subscription admin")
+
+	admin := manager{actionConfig: cfg, restMapper: newTestRESTMapper(), isAdmin: true}
+	candidate, err := admin.getCandidateRelease("ns1", "test-release", clusterScopedChart("test-release"), map[string]interface{}{})
+	require.NoError(t, err)
+	assert.Contains(t, candidate.Manifest, "ClusterRoleBinding")
+}

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -741,7 +741,7 @@ func (hrsi *SubscriberItem) manageHelmCR(indexFile *repo.IndexFile) error {
 				hrsi.Subscription.Namespace, hrsi.Subscription.Name)
 		}
 
-		if err := hrsi.synchronizer.ProcessSubResources(hrsi.Subscription, resources, nil, nil, false, false); err != nil {
+		if err := hrsi.synchronizer.ProcessSubResources(hrsi.Subscription, resources, nil, nil, hrsi.clusterAdmin, false); err != nil {
 			klog.Warningf("failed to put helm manifest to cache (will retry), err: %v", err)
 			doErr = err
 		}

--- a/pkg/subscriber/helmrepo/helm_subscriber_item_clusterscope_test.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item_clusterscope_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helmrepo
+
+// This is a Ginkgo spec (registered into the suite run by
+// TestSubscriptionNamespaceReconcile in helmrepo_subscriber_suite_test.go)
+// rather than a standalone `func TestXxx`, because it depends on the
+// package-level k8sManager/testEnv that BeforeSuite populates.
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
+	releasev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/helmrelease/v1"
+	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+	kubesynchronizer "open-cluster-management.io/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
+)
+
+// This covers the fix in manageHelmCR (helm_subscriber_item.go) that passes
+// the SubscriberItem's live clusterAdmin field into both
+// utils.CreateHelmCRManifest (which stamps the cluster-admin annotation onto
+// the generated HelmRelease CR) and ProcessSubResources, instead of the
+// previous hardcoded false. The annotation on the HelmRelease CR is what
+// pkg/helmrelease/release later reads to decide whether the chart may deploy
+// cluster-scoped resources.
+var _ = Describe("manageHelmCR cluster-admin annotation propagation", func() {
+	It("stamps the cluster-admin annotation on the generated HelmRelease CR only when clusterAdmin is true", func() {
+		mgr, err := manager.New(k8sManager.GetConfig(), manager.Options{
+			Metrics: metricsserver.Options{
+				BindAddress: "0",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		testClient := mgr.GetClient()
+
+		ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+
+		go func() {
+			_ = mgr.Start(ctx)
+		}()
+
+		defer cancel()
+
+		clusterNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "cluster-scope-helmcr"}}
+		Expect(testClient.Create(context.TODO(), clusterNS)).NotTo(HaveOccurred())
+
+		defer func() { _ = testClient.Delete(context.TODO(), clusterNS) }()
+
+		testSub := &appv1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "helmcr-clusteradmin-test",
+				Namespace: "default",
+			},
+		}
+		Expect(testClient.Create(context.TODO(), testSub)).NotTo(HaveOccurred())
+
+		defer func() { _ = testClient.Delete(context.TODO(), testSub) }()
+
+		testChn := &chnv1.Channel{
+			ObjectMeta: metav1.ObjectMeta{Name: "helmcr-clusteradmin-chn", Namespace: "default"},
+			Spec: chnv1.ChannelSpec{
+				Type:     chnv1.ChannelTypeHelmRepo,
+				Pathname: "https://charts.example.com/",
+			},
+		}
+
+		chartDirs := map[string]string{
+			"../../../test/github/helmcharts/chart1/": "../../../test/github/helmcharts/chart1/",
+		}
+
+		indexFile, err := utils.GenerateHelmIndexFile(testSub, "../../..", chartDirs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(indexFile.Entries)).To(Equal(1))
+
+		defaultExtension := &kubesynchronizer.SubscriptionExtension{}
+		syncid := &types.NamespacedName{Namespace: "cluster-scope-helmcr", Name: "cluster-scope-helmcr"}
+		sync, err := kubesynchronizer.CreateSynchronizer(
+			mgr.GetConfig(), k8sManager.GetConfig(), mgr.GetScheme(), syncid, 60, defaultExtension, true, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		hrsi := &SubscriberItem{}
+		hrsi.Channel = testChn
+		hrsi.Subscription = testSub
+		hrsi.synchronizer = sync
+
+		releaseCRName, err := utils.PkgToReleaseCRName(testSub, "chart1")
+		Expect(err).NotTo(HaveOccurred())
+
+		releaseKey := types.NamespacedName{Name: releaseCRName, Namespace: testSub.Namespace}
+		deployedHR := &releasev1.HelmRelease{}
+
+		defer func() { _ = testClient.Delete(context.TODO(), deployedHR) }()
+
+		// Non-admin: the generated HelmRelease CR must not carry the
+		// cluster-admin annotation.
+		hrsi.clusterAdmin = false
+		Expect(hrsi.manageHelmCR(indexFile)).NotTo(HaveOccurred())
+
+		Expect(testClient.Get(context.TODO(), releaseKey, deployedHR)).NotTo(HaveOccurred())
+		Expect(deployedHR.GetAnnotations()[appv1alpha1.AnnotationClusterAdmin]).NotTo(Equal("true"))
+
+		// Admin: re-subscribing with clusterAdmin=true must stamp the
+		// cluster-admin annotation onto the (now-existing) HelmRelease CR.
+		hrsi.clusterAdmin = true
+		Expect(hrsi.manageHelmCR(indexFile)).NotTo(HaveOccurred())
+
+		Expect(testClient.Get(context.TODO(), releaseKey, deployedHR)).NotTo(HaveOccurred())
+		Expect(deployedHR.GetAnnotations()[appv1alpha1.AnnotationClusterAdmin]).To(Equal("true"))
+	})
+})

--- a/pkg/subscriber/helmrepo/helmrepo_subscriber_test.go
+++ b/pkg/subscriber/helmrepo/helmrepo_subscriber_test.go
@@ -72,4 +72,64 @@ var _ = Describe("", func() {
 
 		Expect(defaultSubscriber.UnsubscribeItem(sharedkey)).NotTo(HaveOccurred())
 	})
+
+	// This covers the privilege de-escalation fix in SubscribeItem: clusterAdmin
+	// must track the live cluster-admin annotation on every call, including
+	// being reset to false when the annotation is removed on a later update.
+	It("sets and resets clusterAdmin on the cached SubscriberItem based on the live annotation", func() {
+		adminKey := types.NamespacedName{
+			Name:      "cluster-admin-deescalation-test",
+			Namespace: "default",
+		}
+
+		adminSub := &appv1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      adminKey.Name,
+				Namespace: adminKey.Namespace,
+				Annotations: map[string]string{
+					appv1alpha1.AnnotationClusterAdmin: "true",
+				},
+			},
+			Spec: appv1alpha1.SubscriptionSpec{
+				Channel: sharedkey.String(),
+				Package: "nginx-ingress",
+			},
+		}
+
+		adminSubitem := &appv1alpha1.SubscriberItem{
+			Subscription: adminSub,
+			Channel:      helmchn,
+		}
+
+		Expect(defaultSubscriber.SubscribeItem(adminSubitem)).NotTo(HaveOccurred())
+		Expect(defaultSubscriber.itemmap[adminKey].clusterAdmin).To(BeTrue())
+
+		// Remove the cluster-admin annotation and re-subscribe: the cached
+		// item's clusterAdmin flag must be de-escalated back to false rather
+		// than retaining its previous elevated value.
+		nonAdminSub := adminSub.DeepCopy()
+		nonAdminSub.Annotations = map[string]string{}
+
+		nonAdminSubitem := &appv1alpha1.SubscriberItem{
+			Subscription: nonAdminSub,
+			Channel:      helmchn,
+		}
+
+		Expect(defaultSubscriber.SubscribeItem(nonAdminSubitem)).NotTo(HaveOccurred())
+		Expect(defaultSubscriber.itemmap[adminKey].clusterAdmin).To(BeFalse())
+
+		// Avoid UnsubscribeItem here: Stop() blocks on a WaitGroup until the
+		// background goroutine's in-flight doSubscription attempt against
+		// this (deliberately unreachable) test channel finishes, which can
+		// take up to the subscriber's retry interval (~90s). Since this test
+		// only cares about the clusterAdmin bookkeeping done synchronously
+		// inside SubscribeItem, just drop the cached item and let the
+		// goroutine exit on its own once its current attempt completes.
+		item := defaultSubscriber.itemmap[adminKey]
+		delete(defaultSubscriber.itemmap, adminKey)
+
+		if item != nil && item.stopch != nil {
+			close(item.stopch)
+		}
+	})
 })

--- a/pkg/subscriber/helmrepo/hemrepo_subscriber.go
+++ b/pkg/subscriber/helmrepo/hemrepo_subscriber.go
@@ -123,6 +123,8 @@ func (hrs *Subscriber) SubscribeItem(subitem *appv1alpha1.SubscriberItem) error 
 	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationClusterAdmin], "true") {
 		klog.Info("Cluster admin role enabled on SubscriberItem ", hrssubitem.Subscription.Name)
 		hrssubitem.clusterAdmin = true
+	} else {
+		hrssubitem.clusterAdmin = false
 	}
 
 	hrssubitem.reconcileRate = utils.GetReconcileRate(chnAnnotations, subAnnotations)

--- a/pkg/subscriber/objectbucket/objectbucket_clusterscope_test.go
+++ b/pkg/subscriber/objectbucket/objectbucket_clusterscope_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectbucket
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
+	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+	kubesynchronizer "open-cluster-management.io/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
+	awsutils "open-cluster-management.io/multicloud-operators-subscription/pkg/utils/aws"
+)
+
+// TestObjectBucketRespectsClusterAdminAnnotation verifies that an object
+// store channel subscription honors the cluster-admin annotation: a
+// non-admin subscription must not be able to deploy a cluster-scoped
+// resource (e.g. ClusterRoleBinding), while an admin subscription may.
+func TestObjectBucketRespectsClusterAdminAnnotation(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	testClient := mgr.GetClient()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	clusterNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "cluster-scope-objstore"}}
+	g.Expect(testClient.Create(context.TODO(), clusterNS)).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = testClient.Delete(context.TODO(), clusterNS) }()
+
+	testSub := &appv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "objstore-clusterscope-test",
+			Namespace: "default",
+		},
+		Spec: appv1alpha1.SubscriptionSpec{
+			Channel: sharedkey.String(),
+		},
+	}
+	g.Expect(testClient.Create(context.TODO(), testSub)).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = testClient.Delete(context.TODO(), testSub) }()
+
+	defaultExtension := &kubesynchronizer.SubscriptionExtension{}
+	syncid := &types.NamespacedName{
+		Namespace: "cluster-scope-objstore",
+		Name:      "cluster-scope-objstore",
+	}
+	sync, err := kubesynchronizer.CreateSynchronizer(mgr.GetConfig(), cfg, mgr.GetScheme(), syncid, 60, defaultExtension, true, false)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	crb := &unstructured.Unstructured{}
+	crb.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "rbac.authorization.k8s.io",
+		Version: "v1",
+		Kind:    "ClusterRoleBinding",
+	})
+	crb.SetName("attacker-crb-objstore")
+	crb.SetAnnotations(map[string]string{
+		appv1alpha1.AnnotationHosting: testSub.Namespace + "/" + testSub.Name,
+	})
+	g.Expect(unstructured.SetNestedMap(crb.Object, map[string]interface{}{
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind":     "ClusterRole",
+		"name":     "cluster-admin",
+	}, "roleRef")).NotTo(gomega.HaveOccurred())
+	g.Expect(unstructured.SetNestedSlice(crb.Object, []interface{}{
+		map[string]interface{}{
+			"kind": "User",
+			"name": "attacker",
+		},
+	}, "subjects")).NotTo(gomega.HaveOccurred())
+
+	resourceList := []kubesynchronizer.ResourceUnit{{Resource: crb, Gvk: crb.GroupVersionKind()}}
+	deployedCRBKey := types.NamespacedName{Name: "attacker-crb-objstore"}
+
+	// Non-admin: the ClusterRoleBinding must be rejected and never created.
+	err = sync.ProcessSubResources(testSub, resourceList, nil, nil, false, false)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	deployedCRB := &unstructured.Unstructured{}
+	deployedCRB.SetGroupVersionKind(crb.GroupVersionKind())
+	getErr := testClient.Get(context.TODO(), deployedCRBKey, deployedCRB)
+	g.Expect(errors.IsNotFound(getErr)).To(gomega.BeTrue())
+
+	// Admin: the same ClusterRoleBinding is now allowed to be deployed.
+	err = sync.ProcessSubResources(testSub, resourceList, nil, nil, true, false)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	getErr = testClient.Get(context.TODO(), deployedCRBKey, deployedCRB)
+	g.Expect(getErr).NotTo(gomega.HaveOccurred())
+
+	g.Expect(testClient.Delete(context.TODO(), deployedCRB)).NotTo(gomega.HaveOccurred())
+}
+
+// TestObjectBucketDoSubscriptionRespectsClusterAdmin exercises the real
+// doSubscription() code path in objectbucket_subscriber_item.go end to end
+// (via a fake, fully reachable S3 server) to prove the fix that passes the
+// SubscriberItem's live clusterAdmin field into ProcessSubResources instead
+// of a hardcoded false.
+func TestObjectBucketDoSubscriptionRespectsClusterAdmin(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	testClient := mgr.GetClient()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	clusterNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "cluster-scope-dosub"}}
+	g.Expect(testClient.Create(context.TODO(), clusterNS)).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = testClient.Delete(context.TODO(), clusterNS) }()
+
+	testSub := &appv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "objstore-dosub-test",
+			Namespace: "default",
+		},
+	}
+	g.Expect(testClient.Create(context.TODO(), testSub)).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = testClient.Delete(context.TODO(), testSub) }()
+
+	server, awsHandler, _ := utils.SetupFakeS3Server()
+	defer server.Close()
+	g.Expect(awsHandler).NotTo(gomega.BeNil())
+
+	bucket := "clusterscope-dosub-bucket"
+	g.Expect(awsHandler.Create(bucket)).NotTo(gomega.HaveOccurred())
+
+	crbYAML := `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: attacker-crb-dosub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: User
+  name: attacker
+`
+	g.Expect(awsHandler.Put(bucket, awsutils.DeployableObject{
+		Name:    "crb.yaml",
+		Content: []byte(crbYAML),
+	})).NotTo(gomega.HaveOccurred())
+
+	channel := &chnv1.Channel{
+		ObjectMeta: metav1.ObjectMeta{Name: "objstore-dosub-channel", Namespace: "default"},
+		Spec: chnv1.ChannelSpec{
+			Type:               chnv1.ChannelTypeObjectBucket,
+			Pathname:           server.URL + "/" + bucket,
+			InsecureSkipVerify: true,
+		},
+	}
+
+	defaultExtension := &kubesynchronizer.SubscriptionExtension{}
+	syncid := &types.NamespacedName{Namespace: "cluster-scope-dosub", Name: "cluster-scope-dosub"}
+	sync, err := kubesynchronizer.CreateSynchronizer(mgr.GetConfig(), cfg, mgr.GetScheme(), syncid, 60, defaultExtension, true, false)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	obsi := &SubscriberItem{
+		SubscriberItem: appv1alpha1.SubscriberItem{Subscription: testSub, Channel: channel},
+		synchronizer:   sync,
+		clusterAdmin:   false,
+	}
+
+	deployedCRBKey := types.NamespacedName{Name: "attacker-crb-dosub"}
+	deployedCRB := &unstructured.Unstructured{}
+	deployedCRB.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding",
+	})
+
+	// Non-admin: doSubscription must reject the cluster-scoped resource
+	// bundled in the bucket (ProcessSubResources blocks it internally
+	// without surfacing a top-level error, so doSubscription still reports
+	// success/failure via obsi.successful, not via a panic/crash).
+	obsi.doSubscription()
+
+	getErr := testClient.Get(context.TODO(), deployedCRBKey, deployedCRB)
+	g.Expect(errors.IsNotFound(getErr)).To(gomega.BeTrue())
+
+	// Admin: doSubscription must now allow the same resource through.
+	obsi.clusterAdmin = true
+	obsi.doSubscription()
+
+	g.Expect(testClient.Get(context.TODO(), deployedCRBKey, deployedCRB)).NotTo(gomega.HaveOccurred())
+
+	g.Expect(testClient.Delete(context.TODO(), deployedCRB)).NotTo(gomega.HaveOccurred())
+}
+
+// TestObjectBucketSubscribeItemClusterAdminDeEscalation covers the privilege
+// de-escalation fix in SubscribeItem (objectbucket_subscriber.go):
+// clusterAdmin must track the live cluster-admin annotation on every call,
+// including being reset to false when the annotation is later removed.
+func TestObjectBucketSubscribeItemClusterAdminDeEscalation(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	defaultExtension := &kubesynchronizer.SubscriptionExtension{}
+	syncid := &types.NamespacedName{Namespace: "objstore-deescalation", Name: "objstore-deescalation"}
+	sync, err := kubesynchronizer.CreateSynchronizer(mgr.GetConfig(), cfg, mgr.GetScheme(), syncid, 60, defaultExtension, true, false)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	subscriber := CreateObjectBucketSubsriber(cfg, mgr.GetScheme(), mgr, sync, 60)
+	g.Expect(subscriber).NotTo(gomega.BeNil())
+
+	channel := &chnv1.Channel{
+		ObjectMeta: metav1.ObjectMeta{Name: "objstore-deescalation-chn", Namespace: "default"},
+		Spec: chnv1.ChannelSpec{
+			Type:     chnv1.ChannelTypeObjectBucket,
+			Pathname: "http://127.0.0.1:1/nonexistent-bucket",
+		},
+	}
+
+	itemKey := types.NamespacedName{Name: "objstore-deescalation-test", Namespace: "default"}
+
+	adminSub := &appv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      itemKey.Name,
+			Namespace: itemKey.Namespace,
+			Annotations: map[string]string{
+				appv1alpha1.AnnotationClusterAdmin: "true",
+			},
+		},
+	}
+
+	adminSubitem := &appv1alpha1.SubscriberItem{
+		Subscription: adminSub,
+		Channel:      channel,
+	}
+
+	g.Expect(subscriber.SubscribeItem(adminSubitem)).NotTo(gomega.HaveOccurred())
+	g.Expect(subscriber.itemmap[itemKey].clusterAdmin).To(gomega.BeTrue())
+
+	nonAdminSub := adminSub.DeepCopy()
+	nonAdminSub.Annotations = map[string]string{}
+
+	nonAdminSubitem := &appv1alpha1.SubscriberItem{
+		Subscription: nonAdminSub,
+		Channel:      channel,
+	}
+
+	g.Expect(subscriber.SubscribeItem(nonAdminSubitem)).NotTo(gomega.HaveOccurred())
+	g.Expect(subscriber.itemmap[itemKey].clusterAdmin).To(gomega.BeFalse())
+
+	// Avoid UnsubscribeItem here: Stop() blocks on a WaitGroup until the
+	// background goroutine's in-flight doSubscription attempt against this
+	// (deliberately unreachable) test channel finishes, which can take up
+	// to the subscriber's retry interval (~90s). This test only cares about
+	// the clusterAdmin bookkeeping done synchronously inside SubscribeItem,
+	// so just drop the cached item and let the goroutine exit on its own.
+	item := subscriber.itemmap[itemKey]
+	delete(subscriber.itemmap, itemKey)
+
+	if item != nil && item.stopch != nil {
+		close(item.stopch)
+	}
+}

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber.go
@@ -121,6 +121,8 @@ func (obs *Subscriber) SubscribeItem(subitem *appv1alpha1.SubscriberItem) error 
 	if strings.EqualFold(subAnnotations[appv1alpha1.AnnotationClusterAdmin], "true") {
 		klog.Info("Cluster admin role enabled on SubscriberItem ", obssubitem.Subscription.Name)
 		obssubitem.clusterAdmin = true
+	} else {
+		obssubitem.clusterAdmin = false
 	}
 
 	obssubitem.reconcileRate = utils.GetReconcileRate(chnAnnotations, subAnnotations)

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
@@ -438,7 +438,7 @@ func (obsi *SubscriberItem) doSubscription() {
 
 	allowedGroupResources, deniedGroupResources := utils.GetAllowDenyLists(*obsi.Subscription)
 
-	if err := obsi.synchronizer.ProcessSubResources(obsi.Subscription, resources, allowedGroupResources, deniedGroupResources, false, false); err != nil {
+	if err := obsi.synchronizer.ProcessSubResources(obsi.Subscription, resources, allowedGroupResources, deniedGroupResources, obsi.clusterAdmin, false); err != nil {
 		klog.Error(err)
 
 		obsi.successful = false

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -628,6 +628,19 @@ func (sync *KubeSynchronizer) applyTemplate(nri dynamic.NamespaceableResourceInt
 		return nil
 	}
 
+	// Cluster-scoped resources require subscription-admin privilege. Without this gate a
+	// non-admin user could include a ClusterRoleBinding in a Helm chart and have the
+	// controller (which runs with elevated credentials) apply it on their behalf.
+	if !namespaced && !isAdmin {
+		blockErr := fmt.Errorf("not deployed by a subscription admin. cluster-scoped resource "+
+			"apiVersion: %s kind: %s name: %s is not deployed",
+			tplunit.GetAPIVersion(), tplunit.GetKind(), tplunit.GetName())
+
+		klog.Info(blockErr.Error())
+
+		return blockErr
+	}
+
 	if utils.IsResourceDenied(*tplunit, denyList, isAdmin) {
 		denyError := fmt.Errorf("the resource apiVersion: %s kind: %s is on the deny list. Not deployed",
 			tplunit.GetAPIVersion(), tplunit.GetKind())

--- a/pkg/synchronizer/kubernetes/synchronizer_test.go
+++ b/pkg/synchronizer/kubernetes/synchronizer_test.go
@@ -23,6 +23,7 @@ import (
 	promTestUtils "github.com/prometheus/client_golang/prometheus/testutil"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -635,6 +636,50 @@ var _ = Describe("test ProcessSubResources", Ordered, func() {
 
 		Expect(promTestUtils.CollectAndCount(metrics.LocalDeploymentFailedPullTime)).To(BeZero())
 		Expect(promTestUtils.CollectAndCount(metrics.LocalDeploymentSuccessfulPullTime)).To(BeZero())
+	})
+
+	// Security: a non-subscription-admin must not be able to deploy cluster-scoped resources
+	// (e.g. ClusterRoleBinding) even when no deny list is set, because the controller applies
+	// resources with its own elevated credentials.
+	It("should block cluster-scoped resources for non-admin subscriptions", func() {
+		appsub := workload5Subscription.DeepCopy()
+		Expect(k8sClient.Create(context.TODO(), appsub)).NotTo(HaveOccurred())
+
+		defer k8sClient.Delete(context.TODO(), appsub)
+
+		crb := &unstructured.Unstructured{}
+		crb.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "ClusterRoleBinding",
+		})
+		crb.SetName("attacker-crb")
+		crb.SetAnnotations(map[string]string{
+			appv1alpha1.AnnotationHosting: hostworkload5.Namespace + "/" + hostworkload5.Name,
+		})
+
+		resourceList := []ResourceUnit{{Resource: crb, Gvk: crb.GetObjectKind().GroupVersionKind()}}
+
+		// isAdmin=false, no deny list: cluster-scoped resource must still be rejected.
+		// ProcessSubResources aggregates per-resource errors internally and does not
+		// propagate them as a top-level error (consistent with the other ProcessSubResources
+		// tests in this file), so we assert the rejection via the failure metric and by
+		// confirming the resource was never actually deployed.
+		err = sync.ProcessSubResources(appsub, resourceList, nil, nil, false, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(promTestUtils.CollectAndCount(metrics.LocalDeploymentFailedPullTime)).To(Equal(1))
+		Expect(promTestUtils.CollectAndCount(metrics.LocalDeploymentSuccessfulPullTime)).To(BeZero())
+
+		deployedCRB := &unstructured.Unstructured{}
+		deployedCRB.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "ClusterRoleBinding",
+		})
+		getErr := k8sClient.Get(context.TODO(), types.NamespacedName{Name: "attacker-crb"}, deployedCRB)
+		Expect(getErr).To(HaveOccurred())
+		Expect(errors.IsNotFound(getErr)).To(BeTrue())
 	})
 
 	AfterAll(func() {


### PR DESCRIPTION
…y default (#1703, #1704)

Cherry-pick of:
- #1703: a non subscription-admin shoudl not deploy cluster-scoped resources by default
- #1704: a non subscription-admin should not deploy cluster-scoped resources via helmrepo or object store

* [X] I have taken backward compatibility into consideration.

https://redhat.atlassian.net/browse/ACM-39827
