### PR TITLE
Fix CVEs in subscription operator

### DIFF
--- a/addon/manifests/chart/templates/cluster_role.yaml
+++ b/addon/manifests/chart/templates/cluster_role.yaml
@@ -7,13 +7,15 @@ metadata:
   labels:
     component: "application-manager"
 rules:
+# The application-manager applies arbitrary user-supplied manifests on behalf
+# of subscription-admin Subscriptions, so it requires broad resource access.
+# Scope is enforced in code (subscription-admin gating, namespace coercion,
+# cluster-scoped resources rejected for non-admin Subscriptions) rather than
+# via RBAC. nonResourceURLs are not required by any controller code path and
+# have been removed.
 - apiGroups:
   - '*'
   resources:
-  - '*'
-  verbs:
-  - '*'
-- nonResourceURLs:
   - '*'
   verbs:
   - '*'

--- a/pkg/helmrelease/client/client.go
+++ b/pkg/helmrelease/client/client.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -32,6 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/helmrelease/internal/util/k8sutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -134,9 +136,34 @@ func (c *ownerRefInjectingClient) Build(reader io.Reader, validate bool) (kube.R
 		return resourceList, err
 	}
 
+	isClusterAdmin := c.owner != nil &&
+		strings.EqualFold(c.owner.GetAnnotations()[appv1.AnnotationClusterAdmin], "true")
+	ownerNamespace := ""
+
+	if c.owner != nil {
+		ownerNamespace = c.owner.GetNamespace()
+	}
+
 	err = resourceList.Visit(func(r *resource.Info, err error) error {
 		if err != nil {
 			return err
+		}
+
+		// Constrain rendered chart resources to the HelmRelease's own
+		// namespace unless the HelmRelease was created by a
+		// subscription-admin (annotated by the Subscription controller).
+		// This brings the HelmRelease apply path to parity with the Git
+		// subscriber's namespace coercion / cluster-scoped gating.
+		if !isClusterAdmin {
+			if !r.Namespaced() {
+				return fmt.Errorf("not deployed by a subscription admin: cluster-scoped resource %s/%s kind %s is not deployed",
+					r.Mapping.GroupVersionKind.GroupVersion(), r.Name, r.Mapping.GroupVersionKind.Kind)
+			}
+
+			if r.Namespace != "" && r.Namespace != ownerNamespace {
+				return fmt.Errorf("not deployed by a subscription admin: resource %s/%s kind %s targets namespace %q outside HelmRelease namespace %q",
+					r.Mapping.GroupVersionKind.GroupVersion(), r.Name, r.Mapping.GroupVersionKind.Kind, r.Namespace, ownerNamespace)
+			}
 		}
 
 		objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r.Object)

--- a/pkg/helmrelease/utils/kubernetes.go
+++ b/pkg/helmrelease/utils/kubernetes.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,42 +44,26 @@ func GetPassword(secret *corev1.Secret) string {
 }
 
 // GetConfigMap search the config map containing the helm repo client configuration.
+// The configMapRef.Namespace field is ignored: the ConfigMap is always read from
+// the parent (HelmRelease) namespace to prevent a tenant from referencing a
+// ConfigMap in another tenant's namespace via a directly-created HelmRelease.
 func GetConfigMap(client client.Client, parentNamespace string, configMapRef *corev1.ObjectReference) (configMap *corev1.ConfigMap, err error) {
 	if configMapRef != nil {
 		klog.V(5).Info("Retrieve configMap ", parentNamespace, "/", configMapRef.Name)
 
-		// The secret is copied into the subscription namespace on managed cluster.
-		// If namespace is not specified, look for the secret in the parent (subscription) namespace.
-		// If namespace is specified, FIRST look for the secret in the specified namespace.
-		//     THEN look for the secret in the parent (subscription) namespace.
-		usingParentNs := false
-
-		ns := configMapRef.Namespace
-
-		if ns == "" {
-			ns = parentNamespace
-			usingParentNs = true
+		if configMapRef.Namespace != "" && configMapRef.Namespace != parentNamespace {
+			klog.Warningf("ignoring configMapRef.namespace %q; reading ConfigMap %q from HelmRelease namespace %q",
+				configMapRef.Namespace, configMapRef.Name, parentNamespace)
 		}
 
 		configMap = &corev1.ConfigMap{}
 
-		err = client.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: configMapRef.Name}, configMap)
+		err = client.Get(context.TODO(), types.NamespacedName{Namespace: parentNamespace, Name: configMapRef.Name}, configMap)
 		if err != nil {
-			if !usingParentNs && errors.IsNotFound(err) {
-				// Now try to find the config map in subscription namespace
-				err = client.Get(context.TODO(), types.NamespacedName{Namespace: parentNamespace, Name: configMapRef.Name}, configMap)
-
-				if err != nil {
-					return nil, err
-				}
-
-				klog.Info("configMap found ", "Name: ", configMapRef.Name, " in namespace: ", parentNamespace)
-			} else {
-				return nil, err
-			}
-		} else {
-			klog.Info("ConfigMap found ", "Name:", configMapRef.Name, " in namespace: ", ns)
+			return nil, err
 		}
+
+		klog.Info("ConfigMap found ", "Name:", configMapRef.Name, " in namespace: ", parentNamespace)
 	} else {
 		klog.V(5).Info("no configMapRef defined ", "parentNamespace", parentNamespace)
 	}
@@ -88,42 +71,29 @@ func GetConfigMap(client client.Client, parentNamespace string, configMapRef *co
 	return configMap, err
 }
 
-// GetSecret returns the secret to access the helm-repo
+// GetSecret returns the secret to access the helm-repo.
+// The secretRef.Namespace field is ignored: the Secret is always read from the
+// parent (HelmRelease) namespace to prevent a tenant from exfiltrating a Secret
+// from another namespace by setting repo.secretRef.namespace on a
+// directly-created HelmRelease (the controller fetches with cluster-admin and
+// would otherwise transmit the Secret as Basic-Auth to a tenant-controlled URL).
 func GetSecret(client client.Client, parentNamespace string, secretRef *corev1.ObjectReference) (secret *corev1.Secret, err error) {
 	if secretRef != nil {
 		klog.V(5).Info("retrieve secret :", parentNamespace, "/", secretRef)
 
-		// The secret is copied into the subscription namespace on managed cluster.
-		// If namespace is not specified, look for the secret in the parent (subscription) namespace.
-		// If namespace is specified, FIRST look for the secret in the specified namespace.
-		//     THEN look for the secret in the parent (subscription) namespace.
-		usingParentNs := false
-
-		ns := secretRef.Namespace
-		if ns == "" {
-			ns = parentNamespace
-			usingParentNs = true
+		if secretRef.Namespace != "" && secretRef.Namespace != parentNamespace {
+			klog.Warningf("ignoring secretRef.namespace %q; reading Secret %q from HelmRelease namespace %q",
+				secretRef.Namespace, secretRef.Name, parentNamespace)
 		}
 
 		secret = &corev1.Secret{}
 
-		err = client.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: secretRef.Name}, secret)
+		err = client.Get(context.TODO(), types.NamespacedName{Namespace: parentNamespace, Name: secretRef.Name}, secret)
 		if err != nil {
-			if !usingParentNs && errors.IsNotFound(err) {
-				// Now try to find the secret in subscription namespace
-				err = client.Get(context.TODO(), types.NamespacedName{Namespace: parentNamespace, Name: secretRef.Name}, secret)
-
-				if err != nil {
-					return nil, err
-				}
-
-				klog.Info("Secret found ", "Name: ", secretRef.Name, " in namespace: ", parentNamespace)
-			} else {
-				return nil, err
-			}
-		} else {
-			klog.Info("Secret found ", "Name: ", secretRef.Name, " in namespace: ", ns)
+			return nil, err
 		}
+
+		klog.Info("Secret found ", "Name: ", secretRef.Name, " in namespace: ", parentNamespace)
 	} else {
 		klog.V(5).Info("No secret defined at ", "parentNamespace", parentNamespace)
 	}

--- a/pkg/helmrelease/utils/kubernetes_test.go
+++ b/pkg/helmrelease/utils/kubernetes_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetAccessToken(t *testing.T) {
@@ -53,4 +56,35 @@ func TestGetPassword(t *testing.T) {
 	}
 	pw = GetPassword(secret)
 	assert.Equal(t, "", pw)
+}
+
+// TestGetSecretIgnoresCrossNamespaceRef verifies that secretRef.Namespace is
+// ignored and the Secret is always read from the HelmRelease (parent)
+// namespace, preventing cross-namespace Secret exfiltration via a
+// tenant-authored HelmRelease.
+func TestGetSecretIgnoresCrossNamespaceRef(t *testing.T) {
+	victimSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "victim-ns"},
+		Data:       map[string][]byte{"password": []byte("victim-password")},
+	}
+	tenantSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "tenant-ns"},
+		Data:       map[string][]byte{"password": []byte("tenant-password")},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(victimSecret, tenantSecret).Build()
+
+	// secretRef points at victim-ns, but parentNamespace is tenant-ns.
+	ref := &corev1.ObjectReference{Name: "creds", Namespace: "victim-ns"}
+
+	got, err := GetSecret(cl, "tenant-ns", ref)
+	assert.NoError(t, err)
+	assert.Equal(t, "tenant-ns", got.Namespace, "secret must be read from parent namespace")
+	assert.Equal(t, "tenant-password", string(got.Data["password"]), "must not return cross-namespace secret data")
+
+	// When no Secret exists in the parent namespace the lookup must fail
+	// rather than fall through to the cross-namespace ref.
+	cl2 := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(victimSecret).Build()
+	_, err = GetSecret(cl2, "tenant-ns", ref)
+	assert.Error(t, err, "must not fall back to cross-namespace lookup")
 }

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -1164,7 +1164,12 @@ func ParseNamespacedName(namespacedName string) (string, string) {
 	return parsedstr[0], parsedstr[1]
 }
 
-// FetchChannelReferences best-effort to return the channel secret and configmap if they exist
+// FetchChannelReferences best-effort to return the channel secret and configmap if they exist.
+// The SecretRef.Namespace and ConfigMapRef.Namespace fields are deliberately ignored: the
+// referenced object is always read from the Channel's own namespace. Honouring a
+// tenant-supplied namespace here allowed a namespace-admin to point at a Secret in any
+// namespace; ListAndDeployReferredObject then copies the full Secret (.Data included) into
+// the Subscription namespace where the tenant can read it.
 func FetchChannelReferences(clt client.Client, chn chnv1.Channel) (sec *corev1.Secret, cm *corev1.ConfigMap) {
 	if chn.Spec.SecretRef != nil {
 		secret := &corev1.Secret{}
@@ -1174,8 +1179,9 @@ func FetchChannelReferences(clt client.Client, chn chnv1.Channel) (sec *corev1.S
 			Namespace: chn.GetNamespace(),
 		}
 
-		if chn.Spec.SecretRef.Namespace != "" {
-			chnseckey.Namespace = chn.Spec.SecretRef.Namespace
+		if chn.Spec.SecretRef.Namespace != "" && chn.Spec.SecretRef.Namespace != chn.GetNamespace() {
+			klog.Warningf("ignoring channel %s/%s spec.secretRef.namespace %q; reading Secret from channel namespace",
+				chn.GetNamespace(), chn.GetName(), chn.Spec.SecretRef.Namespace)
 		}
 
 		if err := clt.Get(context.TODO(), chnseckey, secret); err != nil {
@@ -1193,8 +1199,9 @@ func FetchChannelReferences(clt client.Client, chn chnv1.Channel) (sec *corev1.S
 			Namespace: chn.GetNamespace(),
 		}
 
-		if chn.Spec.ConfigMapRef.Namespace != "" {
-			chncmkey.Namespace = chn.Spec.ConfigMapRef.Namespace
+		if chn.Spec.ConfigMapRef.Namespace != "" && chn.Spec.ConfigMapRef.Namespace != chn.GetNamespace() {
+			klog.Warningf("ignoring channel %s/%s spec.configMapRef.namespace %q; reading ConfigMap from channel namespace",
+				chn.GetNamespace(), chn.GetName(), chn.Spec.ConfigMapRef.Namespace)
 		}
 
 		if err := clt.Get(context.TODO(), chncmkey, configMap); err != nil {

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -1792,6 +1792,39 @@ func TestFetchChannelReferences(t *testing.T) {
 	cs, cm := FetchChannelReferences(runtimeClient, chn)
 	g.Expect(cs).To(BeNil()) // Fail to get reference secret
 	g.Expect(cm).To(BeNil()) // Fail to get reference configmap
+
+	// Cross-namespace secretRef must be clamped to the Channel namespace.
+	// Create a secret in a victim namespace and another in the channel
+	// namespace; secretRef.namespace points at the victim but
+	// FetchChannelReferences must return the channel-namespace secret.
+	victimNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "victim-ns-f013"}}
+	g.Expect(runtimeClient.Create(context.TODO(), victimNS)).NotTo(HaveOccurred())
+
+	defer runtimeClient.Delete(context.TODO(), victimNS)
+
+	victimSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "victim-ns-f013"},
+		Data:       map[string][]byte{"password": []byte("victim-password")},
+	}
+	g.Expect(runtimeClient.Create(context.TODO(), victimSecret)).NotTo(HaveOccurred())
+
+	defer runtimeClient.Delete(context.TODO(), victimSecret)
+
+	channelSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data:       map[string][]byte{"password": []byte("channel-password")},
+	}
+	g.Expect(runtimeClient.Create(context.TODO(), channelSecret)).NotTo(HaveOccurred())
+
+	defer runtimeClient.Delete(context.TODO(), channelSecret)
+
+	chn.Spec.SecretRef = &corev1.ObjectReference{Name: "creds", Namespace: "victim-ns-f013"}
+	chn.Spec.ConfigMapRef = nil
+
+	cs, _ = FetchChannelReferences(runtimeClient, chn)
+	g.Expect(cs).NotTo(BeNil())
+	g.Expect(cs.Namespace).To(Equal("default"))
+	g.Expect(string(cs.Data["password"])).To(Equal("channel-password"))
 }
 
 func TestGetClientConfigFromKubeConfig(t *testing.T) {


### PR DESCRIPTION
- CVE-2026-73137 (f003) — clamp HelmRelease secretRef to parent namespace
- CVE-2026-67567 (f004) — gate cluster-scoped/cross-namespace chart resources on subscription-admin
- CVE-2026-72508 (f006) — drop nonResourceURLs from cluster role
- CVE-2026-66878 (f013) — clamp Channel secretRef to subscription namespace
