### PR TITLE
IsClusterAdmin() trusts user-settable annotations on managed clusters

### DIFF
--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	workv1 "open-cluster-management.io/api/work/v1"
 	chnv1alpha1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 
 	plv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -238,6 +239,16 @@ func TestDoReconcileIncludingErrorPaths(t *testing.T) {
 // a stale "cluster-admin: true" annotation (e.g. left over after the
 // subscription is no longer considered hub-propagated) would never be
 // de-escalated.
+//
+// It also covers the fix that gates the spoke-side annotation-trust branch of
+// utils.IsClusterAdmin on isSubscriptionFromManifestWork: on a managed
+// cluster (no ocm-mutating-webhook), the hosting-subscription and
+// cluster-admin annotations are tenant-writable, so a namespace-admin could
+// forge both on a locally-created Subscription. A Helm-repo subscription must
+// only be trusted with cluster-admin when it is verifiably owned by a
+// cluster-scoped AppliedManifestWork that lists it in
+// status.appliedResources, proving it was actually propagated by the hub via
+// ManifestWork rather than forged locally.
 func TestDoReconcileHelmRepoRechecksClusterAdmin(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
@@ -293,8 +304,69 @@ func TestDoReconcileHelmRepoRechecksClusterAdmin(t *testing.T) {
 	defer c.Delete(context.TODO(), instance)
 
 	// The subscription is (simulated as) propagated from the hub and there is
-	// no ACM mutating webhook in this test environment, so IsClusterAdmin
-	// respects the existing cluster-admin annotation and keeps it set.
+	// no ACM mutating webhook in this test environment, but the
+	// hosting-subscription/cluster-admin annotations are tenant-forgeable on
+	// the spoke and there is no AppliedManifestWork ownerReference proving
+	// this Subscription was actually applied by the work agent. IsClusterAdmin
+	// must not trust the forged annotation, and doReconcile must strip it.
+	g.Expect(rec.doReconcile(instance)).NotTo(gomega.HaveOccurred())
+	g.Expect(instance.GetAnnotations()[appv1alpha1.AnnotationClusterAdmin]).NotTo(gomega.Equal("true"))
+
+	// Simulate a legitimate hub propagation: the OCM work agent applies the
+	// Subscription with an ownerReference to a cluster-scoped
+	// AppliedManifestWork and records this Subscription in its
+	// status.appliedResources. A namespace-admin tenant cannot create or
+	// update cluster-scoped AppliedManifestWork resources, so this proves the
+	// Subscription was legitimately delivered by the hub.
+	amw := &workv1.AppliedManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fakehubhash-helmrepo-clusteradmin-recheck-work",
+		},
+		Spec: workv1.AppliedManifestWorkSpec{
+			HubHash:          "fakehubhash",
+			ManifestWorkName: "helmrepo-clusteradmin-recheck-work",
+		},
+	}
+	g.Expect(c.Create(context.TODO(), amw)).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), amw)
+
+	// c is a cache-backed client (mgr.GetClient()), so wait for the newly
+	// created AppliedManifestWork to appear in the informer cache before
+	// attempting to update its status, otherwise the Get inside
+	// Status().Update() can race the cache sync and return NotFound.
+	amwKey := types.NamespacedName{Name: amw.GetName()}
+	g.Eventually(func() error {
+		return c.Get(context.TODO(), amwKey, &workv1.AppliedManifestWork{})
+	}, timeout).Should(gomega.Succeed())
+
+	amw.Status = workv1.AppliedManifestWorkStatus{
+		AppliedResources: []workv1.AppliedManifestResourceMeta{
+			{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     appv1alpha1.SchemeGroupVersion.Group,
+					Resource:  "subscriptions",
+					Namespace: instance.GetNamespace(),
+					Name:      instance.GetName(),
+				},
+				Version: appv1alpha1.SchemeGroupVersion.Version,
+			},
+		},
+	}
+	g.Expect(c.Status().Update(context.TODO(), amw)).NotTo(gomega.HaveOccurred())
+
+	annotations := instance.GetAnnotations()
+	annotations[appv1alpha1.AnnotationClusterAdmin] = "true"
+	instance.SetAnnotations(annotations)
+	instance.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: workv1.GroupVersion.String(),
+		Kind:       "AppliedManifestWork",
+		Name:       amw.GetName(),
+		UID:        amw.GetUID(),
+	}})
+
+	// Now that the AppliedManifestWork ownerReference verifiably lists this
+	// Subscription, the cluster-admin annotation is trusted and kept set.
 	g.Expect(rec.doReconcile(instance)).NotTo(gomega.HaveOccurred())
 	g.Expect(instance.GetAnnotations()[appv1alpha1.AnnotationClusterAdmin]).To(gomega.Equal("true"))
 
@@ -303,7 +375,7 @@ func TestDoReconcileHelmRepoRechecksClusterAdmin(t *testing.T) {
 	// cluster-admin annotation is still stale/true from before. If Helm-repo
 	// subscriptions are correctly rechecked on every reconcile, the stale
 	// annotation must be removed.
-	annotations := instance.GetAnnotations()
+	annotations = instance.GetAnnotations()
 	delete(annotations, appv1alpha1.AnnotationHosting)
 	instance.SetAnnotations(annotations)
 

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -51,6 +51,7 @@ import (
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	workv1 "open-cluster-management.io/api/work/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
@@ -961,7 +962,7 @@ func IsClusterAdmin(client client.Client, sub *appv1.Subscription, eventRecorder
 	isHubSubOfHubSub := isSubPropagatedFromHub && doesWebhookExist && !strings.HasSuffix(sub.GetName(), "-local")
 
 	if isClusterAdminAnnotationTrue && isSubPropagatedFromHub {
-		if !doesWebhookExist || // not on the hub cluster
+		if (!doesWebhookExist && isSubscriptionFromManifestWork(client, sub)) || // not on the hub cluster, and verified to have been applied by the work agent
 			(doesWebhookExist && strings.HasSuffix(sub.GetName(), "-local")) { // on the hub cluster and the subscription has -local suffix
 			if eventRecorder != nil {
 				eventRecorder.RecordEvent(sub, "RoleElevation",
@@ -988,6 +989,45 @@ func IsClusterAdmin(client client.Client, sub *appv1.Subscription, eventRecorder
 	klog.Infof("isClusterAdmin = %v", isClusterAdmin)
 
 	return isClusterAdmin
+}
+
+// isSubscriptionFromManifestWork verifies that the Subscription on a managed
+// cluster was actually applied by the OCM work agent and not directly created
+// by a tenant who forged the hosting-subscription and cluster-admin
+// annotations. The work agent sets an ownerReference to a cluster-scoped
+// AppliedManifestWork on every resource it applies; we resolve that owner and
+// confirm it lists this Subscription in its status.appliedResources. A
+// namespace-admin tenant cannot create or update cluster-scoped
+// AppliedManifestWork resources, so this check is not forgeable.
+func isSubscriptionFromManifestWork(clt client.Client, sub *appv1.Subscription) bool {
+	for _, owner := range sub.GetOwnerReferences() {
+		if owner.Kind != "AppliedManifestWork" ||
+			!strings.HasPrefix(owner.APIVersion, workv1.GroupName+"/") {
+			continue
+		}
+
+		amw := &workv1.AppliedManifestWork{}
+		if err := clt.Get(context.TODO(), types.NamespacedName{Name: owner.Name}, amw); err != nil {
+			klog.Warningf("subscription %s/%s ownerReference AppliedManifestWork %q not resolvable: %v",
+				sub.GetNamespace(), sub.GetName(), owner.Name, err)
+
+			continue
+		}
+
+		for _, r := range amw.Status.AppliedResources {
+			if r.Group == appv1.SchemeGroupVersion.Group &&
+				r.Resource == "subscriptions" &&
+				r.Namespace == sub.GetNamespace() &&
+				r.Name == sub.GetName() {
+				return true
+			}
+		}
+
+		klog.Warningf("subscription %s/%s not listed in AppliedManifestWork %q appliedResources; ignoring cluster-admin annotation",
+			sub.GetNamespace(), sub.GetName(), owner.Name)
+	}
+
+	return false
 }
 
 func matchUserSubAdmin(client client.Client, userIdentity, userGroups string) bool {

--- a/pkg/utils/gitrepo_test.go
+++ b/pkg/utils/gitrepo_test.go
@@ -34,6 +34,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	workv1 "open-cluster-management.io/api/work/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -728,7 +729,8 @@ spec:
 
 	// specify hosting-subscription annotation
 	// specify cluster-admin annotation to be true
-	// In this case, IsClusterAdmin is expected to return true
+	// no AppliedManifestWork owner reference (i.e. tenant-forged annotations on a managed cluster)
+	// In this case, IsClusterAdmin is expected to return false
 	subscriptionYAML = `apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
@@ -746,7 +748,19 @@ spec:
 	err = yaml.Unmarshal([]byte(subscriptionYAML), &subscription)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	g.Expect(IsClusterAdmin(c, subscription, nil)).To(gomega.BeTrue())
+	g.Expect(IsClusterAdmin(c, subscription, nil)).To(gomega.BeFalse())
+
+	// same forged annotations plus a forged ownerReference to an
+	// AppliedManifestWork that does not exist
+	// In this case, IsClusterAdmin is expected to return false
+	subscription.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: workv1.GroupVersion.String(),
+		Kind:       "AppliedManifestWork",
+		Name:       "forged-amw",
+		UID:        "00000000-0000-0000-0000-000000000000",
+	}}
+
+	g.Expect(IsClusterAdmin(c, subscription, nil)).To(gomega.BeFalse())
 
 	// Don't specify hosting-subscription annotation
 	// specify cluster-admin annotation to be true


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.
