### PR TITLE
Defer resource deployment until cluster-admin status resolves instead…

### DIFF
--- a/build/e2e-kc.sh
+++ b/build/e2e-kc.sh
@@ -277,7 +277,23 @@ kubectl get appsub -n default  ansible-hook -o yaml
 kubectl get appsubreport -n default  ansible-hook -o yaml
 kubectl get appsubreport -n cluster1  cluster1 -o yaml
 
-if kubectl get ansiblejobs.tower.ansible.com | grep posthook-test; then
+# The post hook ansible job is only created after the appsub is confirmed to be fully
+# deployed on the managed cluster (IsSubscriptionCompleted). That confirmation can lag
+# behind the subscription's status.ansiblejobs.lastposthookjob field (which is computed
+# earlier), so poll for a bit instead of checking exactly once right after the fixed sleep.
+found=false
+
+for i in $(seq 1 12); do
+    if kubectl get ansiblejobs.tower.ansible.com | grep posthook-test; then
+        found=true
+        break
+    fi
+
+    echo "06-ansiblejob-post: ansiblejobs.tower.ansible.com not found yet, waiting (attempt $i/12)"
+    sleep 10
+done
+
+if [ "$found" = true ]; then
     echo "06-ansiblejob-post: found ansiblejobs.tower.ansible.com"
 else
     echo "06-ansiblejob-post: FAILED: ansiblejobs.tower.ansible.com not found"

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -130,7 +130,10 @@ func (r *ReconcileSubscription) AddClusterAdminAnnotation(sub *appv1.Subscriptio
 		delete(annotations, appv1.AnnotationClusterAdmin) // make sure cluster-admin annotation is removed to begin with
 	}
 
-	if utils.IsClusterAdmin(r.Client, sub, r.Client, r.eventRecorder) {
+	// This call always runs on the hub, where the ocm-mutating-webhook exists, so
+	// IsClusterAdmin never takes the AppliedManifestWork verification branch and the
+	// pending return value is always false here.
+	if isAdmin, _ := utils.IsClusterAdmin(r.Client, sub, r.Client, r.eventRecorder); isAdmin {
 		annotations[appv1.AnnotationClusterAdmin] = "true"
 		sub.SetAnnotations(annotations)
 

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -49,6 +49,14 @@ const (
 	subscriptionBlock  string = "Blocked"
 )
 
+// ErrClusterAdminPending is returned by doReconcile when the subscription's
+// cluster-admin annotation is set but its owning AppliedManifestWork hasn't
+// yet reported the subscription in status.appliedResources. Reconcile treats
+// this as a signal to retry shortly without touching the subscription's
+// status or deploying any resources, since the eventual isAdmin value could
+// still resolve to true and needs to gate the deny list from the start.
+var ErrClusterAdminPending = gerr.New("cluster-admin status is pending AppliedManifestWork status update")
+
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
 * business logic.  Delete these comments after modifying this file.*
@@ -246,6 +254,12 @@ func (r *ReconcileSubscription) Reconcile(ctx context.Context, request reconcile
 		if (strings.EqualFold(annotations[appv1.AnnotationHosting], "") && r.standalone) ||
 			(!strings.EqualFold(annotations[appv1.AnnotationHosting], "") && !r.standalone) {
 			reconcileErr := r.doReconcile(instance)
+
+			if reconcileErr == ErrClusterAdminPending { //nolint:errorlint
+				klog.Infof("cluster-admin status pending for subscription %v, retrying shortly without changing status", request.NamespacedName)
+
+				return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+			}
 
 			// doReconcile updates the subscription. Later this function fails to update the subscription status
 			// if the same subscription resource is used because it has already been updated by reconcile.
@@ -493,7 +507,21 @@ func (r *ReconcileSubscription) doReconcile(instance *appv1.Subscription) error 
 		// permissions than this operator's own in-cluster credentials, so it cannot
 		// read AppliedManifestWork even when hub and local happen to be the same
 		// physical cluster (e.g. local-cluster).
-		if utils.IsClusterAdmin(r.hubclient, instance, r.Client, r.eventRecorder) {
+		isClusterAdmin, isClusterAdminPending := utils.IsClusterAdmin(r.hubclient, instance, r.Client, r.eventRecorder)
+
+		if isClusterAdminPending {
+			// The cluster-admin annotation is set and the subscription was delivered by the
+			// work agent, but the owning AppliedManifestWork hasn't reported this subscription
+			// in status.appliedResources yet (eventual consistency right after creation). Do
+			// not deploy anything this reconcile: treating this window as isAdmin=false would
+			// let deny-listed resources slip through before the deny list can be enforced.
+			klog.Infof("cluster-admin status for subscription %v/%v is still pending on AppliedManifestWork status; skipping this reconcile",
+				instance.GetNamespace(), instance.GetName())
+
+			return ErrClusterAdminPending
+		}
+
+		if isClusterAdmin {
 			klog.Info("ADDING apps.open-cluster-management.io/cluster-admin: true")
 
 			annotations[appv1.AnnotationClusterAdmin] = "true"

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -926,8 +926,17 @@ func IsGitChannel(chType string) bool {
 // in-cluster client), NOT the restricted hub kubeconfig used for hub-side
 // reads, since AppliedManifestWork lives on the managed cluster and the hub
 // credential is generally not permitted to read it.
-func IsClusterAdmin(hubClient client.Client, sub *appv1.Subscription, localClient client.Client, eventRecorder *EventRecorder) bool {
-	isClusterAdmin := false
+//
+// The second return value, isPending, is true when the cluster-admin
+// annotation is present and the subscription's AppliedManifestWork owner has
+// been resolved, but the work agent has not yet reported this subscription in
+// status.appliedResources. This is a normal, transient eventual-consistency
+// window right after the subscription is first applied, and is distinct from
+// isClusterAdmin=false: callers should not treat a pending result as "not
+// admin" (which would let a deny list be silently bypassed on the first
+// reconcile); instead they should defer applying any resources until the
+// status resolves one way or the other.
+func IsClusterAdmin(hubClient client.Client, sub *appv1.Subscription, localClient client.Client, eventRecorder *EventRecorder) (isClusterAdmin, isPending bool) {
 	isUserSubAdmin := false
 	isSubPropagatedFromHub := false
 	isClusterAdminAnnotationTrue := false
@@ -981,15 +990,28 @@ func IsClusterAdmin(hubClient client.Client, sub *appv1.Subscription, localClien
 	isHubSubOfHubSub := isSubPropagatedFromHub && doesWebhookExist && !strings.HasSuffix(sub.GetName(), "-local")
 
 	if isClusterAdminAnnotationTrue && isSubPropagatedFromHub {
-		if (!doesWebhookExist && isSubscriptionFromManifestWork(localClient, sub)) || // not on the hub cluster, and verified to have been applied by the work agent
-			(doesWebhookExist && strings.HasSuffix(sub.GetName(), "-local")) { // on the hub cluster and the subscription has -local suffix
+		switch {
+		case !doesWebhookExist: // not on the hub cluster; verify it was applied by the work agent
+			verified, pending := isSubscriptionFromManifestWork(localClient, sub)
+
+			if verified {
+				if eventRecorder != nil {
+					eventRecorder.RecordEvent(sub, "RoleElevation",
+						"Role was elevated to cluster admin for subscription "+sub.Name, nil)
+				}
+
+				isClusterAdmin = true
+			} else if pending {
+				isPending = true
+			}
+		case strings.HasSuffix(sub.GetName(), "-local"): // on the hub cluster and the subscription has -local suffix
 			if eventRecorder != nil {
 				eventRecorder.RecordEvent(sub, "RoleElevation",
 					"Role was elevated to cluster admin for subscription "+sub.Name, nil)
 			}
 
 			isClusterAdmin = true
-		} else if isHubSubOfHubSub { // hub appsub of a hub appsub
+		case isHubSubOfHubSub: // hub appsub of a hub appsub
 			if eventRecorder != nil {
 				eventRecorder.RecordEvent(sub, "RoleElevation",
 					"Role was elevated to cluster admin for hub subscription of hub subscription "+sub.Name, nil)
@@ -1005,9 +1027,9 @@ func IsClusterAdmin(hubClient client.Client, sub *appv1.Subscription, localClien
 		isClusterAdmin = true
 	}
 
-	klog.Infof("isClusterAdmin = %v", isClusterAdmin)
+	klog.Infof("isClusterAdmin = %v, isPending = %v", isClusterAdmin, isPending)
 
-	return isClusterAdmin
+	return isClusterAdmin, isPending
 }
 
 // isSubscriptionFromManifestWork verifies that the Subscription on a managed
@@ -1018,7 +1040,20 @@ func IsClusterAdmin(hubClient client.Client, sub *appv1.Subscription, localClien
 // confirm it lists this Subscription in its status.appliedResources. A
 // namespace-admin tenant cannot create or update cluster-scoped
 // AppliedManifestWork resources, so this check is not forgeable.
-func isSubscriptionFromManifestWork(clt client.Client, sub *appv1.Subscription) bool {
+//
+// verified is true only once the owning AppliedManifestWork's
+// status.appliedResources actually lists this Subscription.
+//
+// pending is true when an AppliedManifestWork owner was resolved (i.e. it
+// exists and is a real, cluster-scoped object that a tenant could not have
+// forged) but it has not yet reported this Subscription in
+// status.appliedResources. That status is populated asynchronously by the
+// work agent shortly after it creates the AppliedManifestWork and the
+// Subscription, so this is expected to be transient. If the owner reference
+// cannot be resolved at all (e.g. a forged name pointing at an
+// AppliedManifestWork that was never created), pending stays false: that is
+// not eventual consistency, it is indistinguishable from a forgery attempt.
+func isSubscriptionFromManifestWork(clt client.Client, sub *appv1.Subscription) (verified, pending bool) {
 	for _, owner := range sub.GetOwnerReferences() {
 		if owner.Kind != "AppliedManifestWork" ||
 			!strings.HasPrefix(owner.APIVersion, workv1.GroupName+"/") {
@@ -1033,20 +1068,30 @@ func isSubscriptionFromManifestWork(clt client.Client, sub *appv1.Subscription) 
 			continue
 		}
 
+		found := false
+
 		for _, r := range amw.Status.AppliedResources {
 			if r.Group == appv1.SchemeGroupVersion.Group &&
 				r.Resource == "subscriptions" &&
 				r.Namespace == sub.GetNamespace() &&
 				r.Name == sub.GetName() {
-				return true
+				found = true
+
+				break
 			}
 		}
 
-		klog.Warningf("subscription %s/%s not listed in AppliedManifestWork %q appliedResources; ignoring cluster-admin annotation",
+		if found {
+			return true, false
+		}
+
+		klog.Warningf("subscription %s/%s not yet listed in AppliedManifestWork %q appliedResources; cluster-admin status is pending",
 			sub.GetNamespace(), sub.GetName(), owner.Name)
+
+		pending = true
 	}
 
-	return false
+	return false, pending
 }
 
 func matchUserSubAdmin(client client.Client, userIdentity, userGroups string) bool {

--- a/pkg/utils/gitrepo_test.go
+++ b/pkg/utils/gitrepo_test.go
@@ -762,6 +762,66 @@ spec:
 
 	g.Expect(IsClusterAdmin(c, subscription, c, nil)).To(gomega.BeFalse())
 
+	// same annotations, but the ownerReference now points at a real
+	// AppliedManifestWork that exists and has not yet reported this
+	// subscription in status.appliedResources (eventual consistency window
+	// right after the subscription is first created by the work agent).
+	// In this case, IsClusterAdmin is expected to return false, but pending
+	// (the second return value) is expected to be true.
+	realAMW := &workv1.AppliedManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "real-amw-pending",
+		},
+		Spec: workv1.AppliedManifestWorkSpec{
+			HubHash:          "test-hub-hash",
+			ManifestWorkName: "test-manifestwork",
+		},
+	}
+
+	err = c.Create(context.TODO(), realAMW)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), realAMW)
+
+	time.Sleep(1 * time.Second)
+
+	subscription.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: workv1.GroupVersion.String(),
+		Kind:       "AppliedManifestWork",
+		Name:       realAMW.GetName(),
+		UID:        realAMW.GetUID(),
+	}}
+
+	isAdmin, isPending := IsClusterAdmin(c, subscription, c, nil)
+	g.Expect(isAdmin).To(gomega.BeFalse())
+	g.Expect(isPending).To(gomega.BeTrue())
+
+	// same setup, but the AppliedManifestWork's status now lists this
+	// subscription in appliedResources, meaning the work agent has confirmed
+	// it delivered the subscription.
+	// In this case, IsClusterAdmin is expected to return true, and pending is
+	// expected to be false.
+	realAMW.Status.AppliedResources = []workv1.AppliedManifestResourceMeta{
+		{
+			ResourceIdentifier: workv1.ResourceIdentifier{
+				Group:     appv1.SchemeGroupVersion.Group,
+				Resource:  "subscriptions",
+				Namespace: subscription.GetNamespace(),
+				Name:      subscription.GetName(),
+			},
+			Version: "v1",
+		},
+	}
+
+	err = c.Status().Update(context.TODO(), realAMW)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(1 * time.Second)
+
+	isAdmin, isPending = IsClusterAdmin(c, subscription, c, nil)
+	g.Expect(isAdmin).To(gomega.BeTrue())
+	g.Expect(isPending).To(gomega.BeFalse())
+
 	// Don't specify hosting-subscription annotation
 	// specify cluster-admin annotation to be true
 	// In this case, IsClusterAdmin is expected to return false


### PR DESCRIPTION
… of treating it as false

* [X] I have taken backward compatibility into consideration.
